### PR TITLE
feat: stack 1/5 bootstrap classifier core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.env
+bin/
+dist/
+logs/
+*.out
+*.test

--- a/devlogs.md
+++ b/devlogs.md
@@ -1,0 +1,7 @@
+# Devlogs
+
+## 2026-03-10 - Phase 0 kickoff
+
+- Added repo-scoped OpenCode config under `.config/opencode` for reproducible container runs.
+- Started Go implementation for phase-0 PR URL classification pipeline.
+- Locked architecture: Podman stage-1 review + Haiku JSON normalization fallback policy.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/RohanAwhad/pr-review-bot
+
+go 1.24
+
+require (
+	github.com/anthropics/anthropic-sdk-go v1.26.0
+	github.com/invopop/jsonschema v0.13.0
+)

--- a/internal/classifier/types.go
+++ b/internal/classifier/types.go
@@ -1,0 +1,22 @@
+package classifier
+
+type Classification string
+
+const (
+	ClassificationHumanRequired Classification = "human_required"
+	ClassificationNoHuman      Classification = "no_human"
+)
+
+type Decision struct {
+	Classification Classification `json:"classification"`
+	Confidence     float64        `json:"confidence"`
+	Reason         string         `json:"reason"`
+	RunID          string         `json:"run_id"`
+}
+
+type PullRequestRef struct {
+	Owner  string
+	Repo   string
+	Number string
+	URL    string
+}

--- a/internal/classifier/url.go
+++ b/internal/classifier/url.go
@@ -1,0 +1,30 @@
+package classifier
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+func ParsePullRequestURL(raw string) (PullRequestRef, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return PullRequestRef{}, fmt.Errorf("parse PR URL: %w", err)
+	}
+	if u.Scheme != "https" || u.Host != "github.com" {
+		return PullRequestRef{}, fmt.Errorf("unsupported PR URL: %s", raw)
+	}
+
+	parts := strings.Split(strings.Trim(path.Clean(u.Path), "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" || parts[3] == "" {
+		return PullRequestRef{}, fmt.Errorf("invalid PR URL path: %s", u.Path)
+	}
+
+	return PullRequestRef{
+		Owner:  parts[0],
+		Repo:   parts[1],
+		Number: parts[3],
+		URL:    raw,
+	}, nil
+}


### PR DESCRIPTION
## Why
- Establish the phase-0 classifier foundation with explicit core types and PR URL parsing.
- Needed now so later stacked PRs can add runtime and orchestration on a stable interface.

## Scope
- In:
  - Bootstrap Go module and repo hygiene baseline files.
  - Add classifier decision types.
  - Add GitHub PR URL parsing utility.
- Out:
  - Stage-1 Podman runtime.
  - Stage-2 normalization.
  - Pipeline/CLI wiring and logging.

## Changes
- Add `go.mod`, `.gitignore`, and `devlogs.md` bootstrap files.
- Add `internal/classifier/types.go` with classification and decision types.
- Add `internal/classifier/url.go` with strict GitHub PR URL parsing.

## Validation
- [x] `go test ./...` -> pass (`internal/classifier` has no tests in this layer)
- [x] `git diff --name-only main...stack/01-core-parser` -> files limited to bootstrap + classifier core
- [x] Manual check: verified parser contract and type boundaries are minimal and self-contained

## Risk
- Risk level: [x] Low [ ] Medium [ ] High
- Main risk: URL parsing may reject unexpected but valid GitHub URL variants.
- Mitigation: parser remains narrow by design; later tests/layers can extend accepted forms deliberately.
- Rollback: revert this PR; downstream stacked PRs stay blocked until re-applied.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)