### PR TITLE
feat: stack 2/5 add stage-1 runtime

### DIFF
--- a/.config/opencode/.gitignore
+++ b/.config/opencode/.gitignore
@@ -1,0 +1,5 @@
+auth.json
+tui.json
+node_modules/
+themes/
+*.bak

--- a/.config/opencode/README.md
+++ b/.config/opencode/README.md
@@ -1,0 +1,20 @@
+# OpenCode Project Config
+
+This directory stores project-scoped OpenCode config so stage-1 runs are reproducible across machines.
+
+Included:
+- `opencode.json`: provider + model defaults for `google-vertex-anthropic/claude-opus-4-6@default`
+- `agents/auto-accept.md`: non-interactive agent profile so stage-1 runs do not block on tool permission prompts
+
+Do not commit:
+- `auth.json`
+- any local credential files
+- generated caches or local state
+
+Required runtime env vars (provided outside git):
+- `GITHUB_ACCESS_TOKEN`
+- `GOOGLE_CLOUD_PROJECT`
+- `CLOUD_ML_REGION`
+
+Required runtime mount:
+- Google ADC file at `/root/.config/gcloud/application_default_credentials.json`

--- a/.config/opencode/agents/auto-accept.md
+++ b/.config/opencode/agents/auto-accept.md
@@ -1,0 +1,5 @@
+---
+description: Build agent with all permissions auto-accepted. No confirmation prompts.
+mode: primary
+permission: allow
+---

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "google-vertex-anthropic/claude-opus-4-6@default",
+  "provider": {
+    "google-vertex-anthropic": {
+      "options": {
+        "headers": {
+          "anthropic-beta": "context-1m-2025-08-07"
+        }
+      }
+    }
+  }
+}

--- a/docker/stage1/Dockerfile
+++ b/docker/stage1/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/anomalyco/opencode:latest
+
+RUN apk add --no-cache git github-cli bash jq

--- a/internal/stage1/runner.go
+++ b/internal/stage1/runner.go
@@ -1,0 +1,61 @@
+package stage1
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+)
+
+const prompt = "You are stage-1 PR risk classifier. Analyze this checked-out PR branch against main and classify if HUMAN review is required. DO NOT run installs/tests. Only inspect git history, diff, and changed files. End with exactly: CLASSIFICATION: human_required|no_human then CONFIDENCE: <0-1> then REASON: <one sentence>."
+
+type Runner struct {
+	Image    string
+	RepoRoot string
+}
+
+func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	adcPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if adcPath == "" {
+		adcPath = filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+	}
+
+	script := `set -eu; apk add --no-cache git github-cli >/dev/null; path=${PR_URL#https://github.com/}; owner_repo=${path%%/pull/*}; pr_number=${path##*/}; repo_name=${owner_repo##*/}; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
+
+	args := []string{
+		"run", "--rm", "--entrypoint", "sh",
+		"-e", "NO_COLOR=1",
+		"-e", "GITHUB_ACCESS_TOKEN",
+		"-e", "ANTHROPIC_VERTEX_PROJECT_ID",
+		"-e", "CLOUD_ML_REGION",
+		"-e", "GOOGLE_CLOUD_PROJECT",
+		"-e", "VERTEX_LOCATION",
+		"-e", "GOOGLE_CLOUD_LOCATION",
+		"-e", "PR_URL=" + pr.URL,
+		"-e", "STAGE1_PROMPT=" + prompt,
+		"-v", filepath.Join(r.RepoRoot, ".config", "opencode") + ":/root/.config/opencode:ro",
+		"-v", filepath.Join(home, ".local", "share", "opencode", "auth.json") + ":/root/.local/share/opencode/auth.json:ro",
+		"-v", adcPath + ":/root/.config/gcloud/application_default_credentials.json:ro",
+		r.Image,
+		"-lc", script,
+	}
+
+	cmd := exec.CommandContext(ctx, "podman", args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err = cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("run stage-1 container: %w", err)
+	}
+	return out.String(), nil
+}

--- a/internal/stage1/runner.go
+++ b/internal/stage1/runner.go
@@ -29,7 +29,7 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		adcPath = filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
 	}
 
-	script := `set -eu; apk add --no-cache git github-cli >/dev/null; path=${PR_URL#https://github.com/}; owner_repo=${path%%/pull/*}; pr_number=${path##*/}; repo_name=${owner_repo##*/}; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
+	script := `set -eu; apk add --no-cache git github-cli >/dev/null; owner_repo="${PR_OWNER}/${PR_REPO}"; pr_number="${PR_NUMBER}"; repo_name="${PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
 
 	args := []string{
 		"run", "--rm", "--entrypoint", "sh",
@@ -40,7 +40,9 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		"-e", "GOOGLE_CLOUD_PROJECT",
 		"-e", "VERTEX_LOCATION",
 		"-e", "GOOGLE_CLOUD_LOCATION",
-		"-e", "PR_URL=" + pr.URL,
+		"-e", "PR_OWNER=" + pr.Owner,
+		"-e", "PR_REPO=" + pr.Repo,
+		"-e", "PR_NUMBER=" + pr.Number,
 		"-e", "STAGE1_PROMPT=" + prompt,
 		"-v", filepath.Join(r.RepoRoot, ".config", "opencode") + ":/root/.config/opencode:ro",
 		"-v", filepath.Join(home, ".local", "share", "opencode", "auth.json") + ":/root/.local/share/opencode/auth.json:ro",

--- a/internal/stage1/runner.go
+++ b/internal/stage1/runner.go
@@ -29,7 +29,7 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		adcPath = filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
 	}
 
-	script := `set -eu; apk add --no-cache git github-cli >/dev/null; owner_repo="${PR_OWNER}/${PR_REPO}"; pr_number="${PR_NUMBER}"; repo_name="${PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
+	script := `set -eu; apk add --no-cache git github-cli >/dev/null; owner_repo="${PR_REVIEW_BOT_PR_OWNER}/${PR_REVIEW_BOT_PR_REPO}"; pr_number="${PR_REVIEW_BOT_PR_NUMBER}"; repo_name="${PR_REVIEW_BOT_PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
 
 	args := []string{
 		"run", "--rm", "--entrypoint", "sh",
@@ -40,10 +40,10 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		"-e", "GOOGLE_CLOUD_PROJECT",
 		"-e", "VERTEX_LOCATION",
 		"-e", "GOOGLE_CLOUD_LOCATION",
-		"-e", "PR_OWNER=" + pr.Owner,
-		"-e", "PR_REPO=" + pr.Repo,
-		"-e", "PR_NUMBER=" + pr.Number,
-		"-e", "STAGE1_PROMPT=" + prompt,
+		"-e", "PR_REVIEW_BOT_PR_OWNER=" + pr.Owner,
+		"-e", "PR_REVIEW_BOT_PR_REPO=" + pr.Repo,
+		"-e", "PR_REVIEW_BOT_PR_NUMBER=" + pr.Number,
+		"-e", "PR_REVIEW_BOT_STAGE1_PROMPT=" + prompt,
 		"-v", filepath.Join(r.RepoRoot, ".config", "opencode") + ":/root/.config/opencode:ro",
 		"-v", filepath.Join(home, ".local", "share", "opencode", "auth.json") + ":/root/.local/share/opencode/auth.json:ro",
 		"-v", adcPath + ":/root/.config/gcloud/application_default_credentials.json:ro",

--- a/scripts/build_stage1_image.sh
+++ b/scripts/build_stage1_image.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_TAG="${1:-pr-review-bot-stage1:latest}"
+
+podman build \
+  -f "docker/stage1/Dockerfile" \
+  -t "${IMAGE_TAG}" \
+  .
+
+echo "built ${IMAGE_TAG}"


### PR DESCRIPTION
## Why
- Introduce a reproducible stage-1 runtime that can inspect a PR branch in isolation.
- Needed now so downstream normalization/pipeline layers can rely on stable stage-1 execution behavior.

## Scope
- In:
  - Add Podman-based stage-1 runner.
  - Add repo-scoped OpenCode config and non-interactive agent profile.
  - Add stage-1 container build assets.
- Out:
  - Stage-2 normalization.
  - Pipeline classification service and CLI wiring.
  - Logging instrumentation.

## Changes
- Add `internal/stage1/runner.go` to clone PR refs and run OpenCode in container.
- Add `.config/opencode/*` project-scoped runtime configuration.
- Add `docker/stage1/Dockerfile` and `scripts/build_stage1_image.sh`.

## Validation
- [x] `go test ./...` -> pass on `stack/02-stage1-runtime`
- [x] `git diff --name-only stack/01-core-parser...stack/02-stage1-runtime` -> only stage-1 runtime/config/image assets changed
- [x] Manual check: verified runner command wiring for env vars, mounts, and stage-1 prompt flow

## Risk
- Risk level: [ ] Low [x] Medium [ ] High
- Main risk: environment/mount assumptions (`auth.json`, ADC path, container image) can fail on new machines.
- Mitigation: explicit defaults and committed runtime config reduce drift; failures surface for conservative fallback upstream.
- Rollback: revert this PR to remove stage-1 runtime and keep stack at parser-only baseline.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)