### PR TITLE
feat: stack 4/5 add pipeline and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ STAGE1_IMAGE=pr-review-bot-stage1:latest \
 ./bin/classify-pr "https://github.com/RohanAwhad/new-math-mnist/pull/9"
 ```
 
+If `STAGE1_IMAGE` is not set, the CLI defaults to `pr-review-bot-stage1:latest`.
+
 Output shape:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The repository-scoped OpenCode config lives in `.config/opencode`.
 ## Run classifier
 
 ```bash
-STAGE1_IMAGE=pr-review-bot-stage1:latest \
+PR_REVIEW_BOT_STAGE1_IMAGE=pr-review-bot-stage1:latest \
 ./bin/classify-pr "https://github.com/RohanAwhad/new-math-mnist/pull/9"
 ```
 
-If `STAGE1_IMAGE` is not set, the CLI defaults to `pr-review-bot-stage1:latest`.
+If `PR_REVIEW_BOT_STAGE1_IMAGE` is not set, the CLI falls back to `STAGE1_IMAGE`, then `pr-review-bot-stage1:latest`.
 
 Output shape:
 
@@ -49,5 +49,5 @@ Output shape:
 ## Notes
 
 - Stage-1 timeout is fixed at 30 minutes.
-- Confidence threshold defaults to `0.65` and can be overridden with `MIN_CONFIDENCE`.
+- Confidence threshold defaults to `0.5` and can be overridden with `MIN_CONFIDENCE`.
 - Normalizer model defaults to `claude-haiku-4-5@20251001` and can be overridden with `NORMALIZER_MODEL`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# PR Review Bot (Phase 0)
+
+Phase 0 implements:
+- Input: GitHub PR URL
+- Output: JSON classification (`human_required` or `no_human`)
+
+Architecture:
+- Stage 1 (inside Podman): `opencode` (Opus 4.6) reviews checked-out PR
+- Stage 2 (in Go process): Haiku normalizes stage-1 output to structured JSON
+- Failure policy: any error/timeout/low confidence => `human_required`
+
+## Prerequisites
+
+- `podman`
+- read-only `GITHUB_ACCESS_TOKEN`
+- Google ADC at `~/.config/gcloud/application_default_credentials.json`
+- env vars:
+  - `GOOGLE_CLOUD_PROJECT`
+  - `CLOUD_ML_REGION`
+
+The repository-scoped OpenCode config lives in `.config/opencode`.
+
+## Build stage-1 image
+
+```bash
+./scripts/build_stage1_image.sh pr-review-bot-stage1:latest
+```
+
+## Run classifier
+
+```bash
+STAGE1_IMAGE=pr-review-bot-stage1:latest \
+./bin/classify-pr "https://github.com/RohanAwhad/new-math-mnist/pull/9"
+```
+
+Output shape:
+
+```json
+{
+  "classification": "human_required",
+  "confidence": 0,
+  "reason": "stage-2 confidence too low: 0.42",
+  "run_id": "run-1741740000-123456"
+}
+```
+
+## Notes
+
+- Stage-1 timeout is fixed at 30 minutes.
+- Confidence threshold defaults to `0.65` and can be overridden with `MIN_CONFIDENCE`.
+- Normalizer model defaults to `claude-haiku-4-5@20251001` and can be overridden with `NORMALIZER_MODEL`.

--- a/cmd/classify-pr/main.go
+++ b/cmd/classify-pr/main.go
@@ -37,7 +37,7 @@ func main() {
 	project := envOr("GOOGLE_CLOUD_PROJECT", os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"))
 	region := envOr("CLOUD_ML_REGION", "us-east5")
 	model := envOr("NORMALIZER_MODEL", "claude-haiku-4-5@20251001")
-	image := envOr("STAGE1_IMAGE", "pr-review-bot-stage1:latest")
+	image := envOr("PR_REVIEW_BOT_STAGE1_IMAGE", envOr("STAGE1_IMAGE", "pr-review-bot-stage1:latest"))
 
 	service := pipeline.Service{
 		Stage1: stage1.Runner{
@@ -62,10 +62,10 @@ func runID() string {
 }
 
 func confidenceThreshold() float64 {
-	value := envOr("MIN_CONFIDENCE", "0.65")
+	value := envOr("MIN_CONFIDENCE", "0.5")
 	v, err := strconv.ParseFloat(value, 64)
 	if err != nil || v < 0 || v > 1 {
-		return 0.65
+		return 0.5
 	}
 	return v
 }

--- a/cmd/classify-pr/main.go
+++ b/cmd/classify-pr/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/RohanAwhad/pr-review-bot/internal/normalize"
@@ -26,6 +29,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "resolve working directory: %v\n", err)
 		os.Exit(1)
 	}
+	loadDotEnv(filepath.Join(wd, ".env"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
@@ -33,7 +37,7 @@ func main() {
 	project := envOr("GOOGLE_CLOUD_PROJECT", os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"))
 	region := envOr("CLOUD_ML_REGION", "us-east5")
 	model := envOr("NORMALIZER_MODEL", "claude-haiku-4-5@20251001")
-	image := envOr("STAGE1_IMAGE", "ghcr.io/anomalyco/opencode:latest")
+	image := envOr("STAGE1_IMAGE", "pr-review-bot-stage1:latest")
 
 	service := pipeline.Service{
 		Stage1: stage1.Runner{
@@ -71,4 +75,35 @@ func envOr(key string, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func loadDotEnv(path string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		if key == "" || os.Getenv(key) != "" {
+			continue
+		}
+
+		value := strings.TrimSpace(parts[1])
+		value = strings.TrimPrefix(value, "\"")
+		value = strings.TrimSuffix(value, "\"")
+		_ = os.Setenv(key, value)
+	}
 }

--- a/cmd/classify-pr/main.go
+++ b/cmd/classify-pr/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/normalize"
+	"github.com/RohanAwhad/pr-review-bot/internal/pipeline"
+	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: classify-pr <github-pr-url>\n")
+		os.Exit(2)
+	}
+	prURL := os.Args[1]
+
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve working directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	project := envOr("GOOGLE_CLOUD_PROJECT", os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"))
+	region := envOr("CLOUD_ML_REGION", "us-east5")
+	model := envOr("NORMALIZER_MODEL", "claude-haiku-4-5@20251001")
+	image := envOr("STAGE1_IMAGE", "ghcr.io/anomalyco/opencode:latest")
+
+	service := pipeline.Service{
+		Stage1: stage1.Runner{
+			Image:    image,
+			RepoRoot: wd,
+		},
+		Normalizer:    normalize.New(ctx, region, project, model),
+		MinConfidence: confidenceThreshold(),
+	}
+
+	decision := service.Classify(ctx, prURL, runID())
+	out, err := json.MarshalIndent(decision, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "encode decision JSON: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}
+
+func runID() string {
+	return fmt.Sprintf("run-%d-%06d", time.Now().Unix(), rand.Intn(1000000))
+}
+
+func confidenceThreshold() float64 {
+	value := envOr("MIN_CONFIDENCE", "0.65")
+	v, err := strconv.ParseFloat(value, 64)
+	if err != nil || v < 0 || v > 1 {
+		return 0.65
+	}
+	return v
+}
+
+func envOr(key string, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/devlogs.md
+++ b/devlogs.md
@@ -5,3 +5,9 @@
 - Added repo-scoped OpenCode config under `.config/opencode` for reproducible container runs.
 - Started Go implementation for phase-0 PR URL classification pipeline.
 - Locked architecture: Podman stage-1 review + Haiku JSON normalization fallback policy.
+
+## 2026-03-11 - Phase 0 implementation
+
+- Added Go pipeline: PR URL parsing, stage-1 runner, stage-2 normalizer, and fallback policy.
+- Added stage-1 image Dockerfile and build script for reproducible dependencies (`git`, `gh`, `bash`, `jq`).
+- Added URL parser tests and README usage for running classification end-to-end.

--- a/internal/classifier/url_test.go
+++ b/internal/classifier/url_test.go
@@ -1,0 +1,20 @@
+package classifier
+
+import "testing"
+
+func TestParsePullRequestURL(t *testing.T) {
+	pr, err := ParsePullRequestURL("https://github.com/RohanAwhad/new-math-mnist/pull/9")
+	if err != nil {
+		t.Fatalf("expected URL parse success: %v", err)
+	}
+	if pr.Owner != "RohanAwhad" || pr.Repo != "new-math-mnist" || pr.Number != "9" {
+		t.Fatalf("unexpected parsed PR ref: %+v", pr)
+	}
+}
+
+func TestParsePullRequestURLRejectsInvalidPath(t *testing.T) {
+	_, err := ParsePullRequestURL("https://github.com/RohanAwhad/new-math-mnist/issues/9")
+	if err == nil {
+		t.Fatal("expected parse error for non-PR URL")
+	}
+}

--- a/internal/pipeline/service.go
+++ b/internal/pipeline/service.go
@@ -1,0 +1,58 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+	"github.com/RohanAwhad/pr-review-bot/internal/normalize"
+	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
+)
+
+type Service struct {
+	Stage1        stage1.Runner
+	Normalizer    normalize.Normalizer
+	MinConfidence float64
+}
+
+func (s Service) Classify(ctx context.Context, prURL string, runID string) classifier.Decision {
+	pr, err := classifier.ParsePullRequestURL(prURL)
+	if err != nil {
+		return fallback(runID, fmt.Sprintf("invalid pr url: %v", err))
+	}
+
+	stage1Output, err := s.Stage1.Run(ctx, pr)
+	if err != nil {
+		return fallback(runID, fmt.Sprintf("stage-1 failed: %v", err))
+	}
+
+	decision, err := s.Normalizer.Classify(ctx, stage1Output)
+	if err != nil {
+		return fallback(runID, fmt.Sprintf("stage-2 failed: %v", err))
+	}
+	decision.RunID = runID
+
+	if decision.Confidence < s.MinConfidence {
+		return fallback(runID, fmt.Sprintf("stage-2 confidence too low: %.2f", decision.Confidence))
+	}
+
+	if decision.Classification != classifier.ClassificationHumanRequired && decision.Classification != classifier.ClassificationNoHuman {
+		return fallback(runID, "stage-2 returned unsupported classification")
+	}
+
+	if decision.Reason == "" {
+		decision.Reason = "stage-2 returned empty reason"
+		decision.Classification = classifier.ClassificationHumanRequired
+	}
+
+	return decision
+}
+
+func fallback(runID string, reason string) classifier.Decision {
+	return classifier.Decision{
+		Classification: classifier.ClassificationHumanRequired,
+		Confidence:     0,
+		Reason:         reason,
+		RunID:          runID,
+	}
+}

--- a/internal/pipeline/service.go
+++ b/internal/pipeline/service.go
@@ -41,8 +41,7 @@ func (s Service) Classify(ctx context.Context, prURL string, runID string) class
 	}
 
 	if decision.Reason == "" {
-		decision.Reason = "stage-2 returned empty reason"
-		decision.Classification = classifier.ClassificationHumanRequired
+		return fallback(runID, "stage-2 returned empty reason")
 	}
 
 	return decision

--- a/internal/stage1/runner.go
+++ b/internal/stage1/runner.go
@@ -29,7 +29,7 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		adcPath = filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
 	}
 
-	script := `set -eu; apk add --no-cache git github-cli >/dev/null; owner_repo="${PR_REVIEW_BOT_PR_OWNER}/${PR_REVIEW_BOT_PR_REPO}"; pr_number="${PR_REVIEW_BOT_PR_NUMBER}"; repo_name="${PR_REVIEW_BOT_PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
+	script := `set -eu; owner_repo="${PR_REVIEW_BOT_PR_OWNER}/${PR_REVIEW_BOT_PR_REPO}"; pr_number="${PR_REVIEW_BOT_PR_NUMBER}"; repo_name="${PR_REVIEW_BOT_PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
 
 	args := []string{
 		"run", "--rm", "--entrypoint", "sh",


### PR DESCRIPTION
## Why
- Connect parser, stage-1 runtime, and stage-2 normalizer into one phase-0 classification path.
- Needed now to provide a runnable CLI and conservative decision policy end-to-end.

## Scope
- In:
  - Add pipeline service orchestration with fallback policy.
  - Add `classify-pr` CLI entrypoint.
  - Add parser tests and phase-0 usage docs.
  - Add runtime default hardening (`.env` load, image/model defaults, empty-reason guard).
- Out:
  - Structured file/stream logging instrumentation.

## Changes
- Add `internal/pipeline/service.go` with parse -> stage-1 -> stage-2 flow and confidence gating.
- Add `cmd/classify-pr/main.go` for JSON decision output and runtime setup.
- Add `internal/classifier/url_test.go` and README/devlogs updates for usage and architecture.

## Validation
- [x] `go test ./...` -> pass on `stack/04-pipeline-cli`
- [x] `git diff --name-only stack/03-stage2-normalizer...stack/04-pipeline-cli` -> changes limited to pipeline/CLI/tests/docs/defaults
- [x] Manual check: verified fallback behavior remains `human_required` for invalid URL, low confidence, or stage failures

## Risk
- Risk level: [ ] Low [x] Medium [ ] High
- Main risk: fallback/default logic may route too many cases to `human_required` or hide edge-case misconfigurations.
- Mitigation: conservative-by-design policy plus explicit reason strings keeps behavior transparent for iteration.
- Rollback: revert this PR to return to pre-CLI, component-only stack.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)