### PR TITLE
feat: stack 5/5 add logging and instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ Output shape:
 - Stage-1 timeout is fixed at 30 minutes.
 - Confidence threshold defaults to `0.5` and can be overridden with `MIN_CONFIDENCE`.
 - Normalizer model defaults to `claude-haiku-4-5@20251001` and can be overridden with `NORMALIZER_MODEL`.
+- Logs are written to `logs/classify-pr.log` and mirrored to stderr.
+- `LOGGING_LEVEL` controls verbosity (`debug`, `info`, `warn`, `error`); default is `warn`.

--- a/cmd/classify-pr/main.go
+++ b/cmd/classify-pr/main.go
@@ -5,13 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/RohanAwhad/pr-review-bot/internal/logging"
 	"github.com/RohanAwhad/pr-review-bot/internal/normalize"
 	"github.com/RohanAwhad/pr-review-bot/internal/pipeline"
 	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
@@ -31,6 +34,24 @@ func main() {
 	}
 	loadDotEnv(filepath.Join(wd, ".env"))
 
+	logger, logSink, logPath, err := logging.New("classify-pr")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configure logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer logSink.Close()
+	slog.SetDefault(logger)
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Error("panic recovered", "panic", recovered, "stack", string(debug.Stack()))
+			os.Exit(1)
+		}
+	}()
+
+	id := runID()
+	runLogger := logger.With("run_id", id, "pr_url", prURL)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
@@ -38,22 +59,31 @@ func main() {
 	region := envOr("CLOUD_ML_REGION", "us-east5")
 	model := envOr("NORMALIZER_MODEL", "claude-haiku-4-5@20251001")
 	image := envOr("PR_REVIEW_BOT_STAGE1_IMAGE", envOr("STAGE1_IMAGE", "pr-review-bot-stage1:latest"))
+	runLogger.Info("starting classification", "image", image, "normalizer_model", model)
+
+	normalizer := normalize.New(ctx, region, project, model)
+	normalizer.Logger = runLogger
 
 	service := pipeline.Service{
 		Stage1: stage1.Runner{
 			Image:    image,
 			RepoRoot: wd,
+			Logger:   runLogger,
 		},
-		Normalizer:    normalize.New(ctx, region, project, model),
+		Normalizer:    normalizer,
 		MinConfidence: confidenceThreshold(),
+		Logger:        runLogger,
 	}
 
-	decision := service.Classify(ctx, prURL, runID())
+	decision := service.Classify(ctx, prURL, id)
+	runLogger.Info("classification completed", "classification", decision.Classification, "confidence", decision.Confidence)
 	out, err := json.MarshalIndent(decision, "", "  ")
 	if err != nil {
+		runLogger.Error("encode decision JSON", "error", err)
 		fmt.Fprintf(os.Stderr, "encode decision JSON: %v\n", err)
 		os.Exit(1)
 	}
+	runLogger.Debug("writing decision JSON to stdout", "log_path", logPath)
 	fmt.Println(string(out))
 }
 

--- a/devlogs.md
+++ b/devlogs.md
@@ -11,3 +11,9 @@
 - Added Go pipeline: PR URL parsing, stage-1 runner, stage-2 normalizer, and fallback policy.
 - Added stage-1 image Dockerfile and build script for reproducible dependencies (`git`, `gh`, `bash`, `jq`).
 - Added URL parser tests and README usage for running classification end-to-end.
+
+## 2026-03-11 - Logging baseline
+
+- Added structured logging with stderr + file sinks at `logs/classify-pr.log`.
+- Added `LOGGING_LEVEL` support with default `warn` and optional `debug|info|warn|error`.
+- Added pipeline/stage-1/stage-2 logging for failures and fallback decisions.

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func New(component string) (*slog.Logger, io.Closer, string, error) {
+	logDir := filepath.Join(".", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return nil, nil, "", err
+	}
+
+	logPath := filepath.Join(logDir, component+".log")
+	file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	handler := slog.NewTextHandler(io.MultiWriter(os.Stderr, file), &slog.HandlerOptions{
+		Level: parseLevel(os.Getenv("LOGGING_LEVEL")),
+	})
+
+	logger := slog.New(handler).With("component", component)
+	return logger, file, logPath, nil
+}
+
+func parseLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelWarn
+	}
+}

--- a/internal/normalize/haiku.go
+++ b/internal/normalize/haiku.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
 	"github.com/anthropics/anthropic-sdk-go"
@@ -14,6 +15,7 @@ import (
 type Normalizer struct {
 	client anthropic.Client
 	model  anthropic.Model
+	Logger *slog.Logger
 }
 
 type output struct {
@@ -28,6 +30,9 @@ func New(ctx context.Context, region string, projectID string, model string) Nor
 }
 
 func (n Normalizer) Classify(ctx context.Context, stage1Output string) (classifier.Decision, error) {
+	logger := n.logger().With("model", n.model)
+	logger.Info("running stage-2 normalizer")
+
 	tool := anthropic.ToolParam{
 		Name:        "emit_classification",
 		Description: anthropic.String("Emit the final PR routing classification."),
@@ -44,6 +49,7 @@ func (n Normalizer) Classify(ctx context.Context, stage1Output string) (classifi
 		Tools: tools,
 	})
 	if err != nil {
+		logger.Error("normalize call failed", "error", err)
 		return classifier.Decision{}, fmt.Errorf("normalize with haiku: %w", err)
 	}
 
@@ -55,18 +61,22 @@ func (n Normalizer) Classify(ctx context.Context, stage1Output string) (classifi
 
 		payload, err := json.Marshal(toolUse.Input)
 		if err != nil {
+			logger.Error("marshal tool input", "error", err)
 			return classifier.Decision{}, fmt.Errorf("marshal tool input: %w", err)
 		}
 
 		var out output
 		if err := json.Unmarshal(payload, &out); err != nil {
+			logger.Error("decode tool input", "error", err)
 			return classifier.Decision{}, fmt.Errorf("decode tool input: %w", err)
 		}
 
 		classification := classifier.Classification(out.Classification)
 		if classification != classifier.ClassificationHumanRequired && classification != classifier.ClassificationNoHuman {
+			logger.Error("invalid classification", "classification", out.Classification)
 			return classifier.Decision{}, fmt.Errorf("invalid classification from normalizer: %s", out.Classification)
 		}
+		logger.Debug("stage-2 normalizer produced classification", "classification", classification, "confidence", out.Confidence)
 
 		return classifier.Decision{
 			Classification: classification,
@@ -75,7 +85,15 @@ func (n Normalizer) Classify(ctx context.Context, stage1Output string) (classifi
 		}, nil
 	}
 
+	logger.Error("normalizer returned no tool call")
 	return classifier.Decision{}, fmt.Errorf("normalizer did not emit classification tool call")
+}
+
+func (n Normalizer) logger() *slog.Logger {
+	if n.Logger != nil {
+		return n.Logger
+	}
+	return slog.Default()
 }
 
 func schema[T any]() anthropic.ToolInputSchemaParam {

--- a/internal/pipeline/service.go
+++ b/internal/pipeline/service.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
 	"github.com/RohanAwhad/pr-review-bot/internal/normalize"
@@ -13,38 +14,57 @@ type Service struct {
 	Stage1        stage1.Runner
 	Normalizer    normalize.Normalizer
 	MinConfidence float64
+	Logger        *slog.Logger
 }
 
 func (s Service) Classify(ctx context.Context, prURL string, runID string) classifier.Decision {
+	logger := s.logger()
+	logger.Info("pipeline classification started")
+
 	pr, err := classifier.ParsePullRequestURL(prURL)
 	if err != nil {
+		logger.Error("parse PR URL failed", "error", err)
 		return fallback(runID, fmt.Sprintf("invalid pr url: %v", err))
 	}
 
 	stage1Output, err := s.Stage1.Run(ctx, pr)
 	if err != nil {
+		logger.Error("stage-1 failed", "error", err)
 		return fallback(runID, fmt.Sprintf("stage-1 failed: %v", err))
 	}
 
 	decision, err := s.Normalizer.Classify(ctx, stage1Output)
 	if err != nil {
+		logger.Error("stage-2 failed", "error", err)
 		return fallback(runID, fmt.Sprintf("stage-2 failed: %v", err))
 	}
 	decision.RunID = runID
 
 	if decision.Confidence < s.MinConfidence {
+		logger.Error("stage-2 confidence below threshold", "confidence", decision.Confidence, "min_confidence", s.MinConfidence)
 		return fallback(runID, fmt.Sprintf("stage-2 confidence too low: %.2f", decision.Confidence))
 	}
 
 	if decision.Classification != classifier.ClassificationHumanRequired && decision.Classification != classifier.ClassificationNoHuman {
+		logger.Error("stage-2 returned unsupported classification", "classification", decision.Classification)
 		return fallback(runID, "stage-2 returned unsupported classification")
 	}
 
 	if decision.Reason == "" {
+		logger.Error("stage-2 returned empty reason")
 		return fallback(runID, "stage-2 returned empty reason")
 	}
 
+	logger.Info("pipeline classification completed", "classification", decision.Classification, "confidence", decision.Confidence)
+
 	return decision
+}
+
+func (s Service) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
 }
 
 func fallback(runID string, reason string) classifier.Decision {

--- a/internal/stage1/runner.go
+++ b/internal/stage1/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,11 +17,16 @@ const prompt = "You are stage-1 PR risk classifier. Analyze this checked-out PR 
 type Runner struct {
 	Image    string
 	RepoRoot string
+	Logger   *slog.Logger
 }
 
 func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, error) {
+	logger := r.logger().With("owner", pr.Owner, "repo", pr.Repo, "pr_number", pr.Number)
+	logger.Info("running stage-1 in podman", "image", r.Image)
+
 	home, err := os.UserHomeDir()
 	if err != nil {
+		logger.Error("resolve home directory", "error", err)
 		return "", fmt.Errorf("resolve home directory: %w", err)
 	}
 
@@ -57,7 +63,16 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 	cmd.Stderr = &out
 	err = cmd.Run()
 	if err != nil {
+		logger.Error("stage-1 podman run failed", "error", err, "output", out.String())
 		return out.String(), fmt.Errorf("run stage-1 container: %w", err)
 	}
+	logger.Debug("stage-1 podman run completed", "output_len", out.Len())
 	return out.String(), nil
+}
+
+func (r Runner) logger() *slog.Logger {
+	if r.Logger != nil {
+		return r.Logger
+	}
+	return slog.Default()
 }


### PR DESCRIPTION
## Why
- Add baseline observability so phase-0 execution can be debugged from structured logs.
- Needed now to make stage and fallback behavior diagnosable during early rollout.

## Scope
- In:
  - Add shared logging package with file sink + stderr mirror.
  - Wire run-scoped logging into CLI and panic path.
  - Add stage-1/stage-2/pipeline logging instrumentation.
  - Document log path and `LOGGING_LEVEL` behavior.
- Out:
  - New classification logic or policy changes.

## Changes
- Add `internal/logging/logger.go` with `logs/<component>.log` sink and level parsing.
- Update CLI wiring to initialize logging and include run identifiers in logs.
- Add detailed error/debug logs in `internal/stage1/runner.go`, `internal/normalize/haiku.go`, and `internal/pipeline/service.go`; update README/devlogs.

## Validation
- [x] `go test ./...` -> pass on `stack/05-logging-docs`
- [x] `git diff --name-only main...stack/05-logging-docs` -> changes limited to logging package/instrumentation/docs
- [x] `go run ./cmd/classify-pr "https://github.com/RohanAwhad/new-math-mnist/issues/9"` -> returned fallback JSON with `run_id=run-1773206164-373095`
- [x] File-sink proof: `logs/classify-pr.log` line 5 contains the same run id and error log (`msg="parse PR URL failed" ... `run_id=run-1773206164-373095`)

## Risk
- Risk level: [x] Low [ ] Medium [ ] High
- Main risk: log output may include too little or too much detail for operator needs.
- Mitigation: level control via `LOGGING_LEVEL` and focused stage-specific messages.
- Rollback: revert this PR to remove logging package/instrumentation without affecting classification behavior.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)