### PR TITLE
chore: add repository pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Why
+- <problem this PR solves>
+- <why now / linked issue>
+
+## Scope
+- In:
+  - <included item>
+  - <included item>
+- Out:
+  - <explicitly not in this PR>
+
+## Changes
+- <change 1>
+- <change 2>
+- <change 3>
+
+## Validation
+- [ ] `command` -> <result>
+- [ ] `command` -> <result>
+- [ ] Manual check: <what was verified>
+
+## Risk
+- Risk level: [ ] Low [ ] Medium [ ] High
+- Main risk: <what could break>
+- Mitigation: <why risk is controlled>
+- Rollback: <revert plan>
+
+## Checklist
+- [ ] Self-review done
+- [ ] No unrelated changes
+- [ ] Tests/type checks updated as needed
+- [ ] Docs updated (if behavior/usage changed)
+
+---
+
+<!-- BUG FIX ADD-ON (uncomment when relevant)
+## Bug Details
+- Repro steps:
+  1. ...
+  2. ...
+- Root cause:
+  - ...
+- Regression coverage:
+  - <test name/command>
+-->
+
+<!-- FEATURE ADD-ON (uncomment when relevant)
+## Feature Rollout
+- Backward compatibility: <yes/no + notes>
+- Feature flag: <name / none>
+- Follow-up work:
+  - ...
+-->


### PR DESCRIPTION
## Why
- Standardize PR descriptions so reviews are faster and risk/validation are consistently documented.
- Needed now because the repo is moving to stacked PRs and benefits from uniform review context.

## Scope
- In:
  - Add a default GitHub PR template at `.github/pull_request_template.md`.
  - Mirror the template structure used in `api_adapter_v2026/benchmarks/new_math_ops`.
- Out:
  - Any code/runtime behavior changes.
  - Existing stacked PR commit contents.

## Changes
- Add `.github/pull_request_template.md`.
- Include required sections: Why, Scope, Changes, Validation, Risk, Checklist.
- Include optional bug-fix and feature-rollout add-on blocks as comments.

## Validation
- [x] `git diff --name-only origin/main...HEAD` -> `.github/pull_request_template.md`
- [x] `git show --stat --oneline HEAD` -> 1 file changed, 53 insertions
- [x] Manual check: verified template matches `new_math_ops/.github/pull_request_template.md`

## Risk
- Risk level: [x] Low [ ] Medium [ ] High
- Main risk: contributors may partially fill template sections.
- Mitigation: explicit checklist + required headings improve consistency over current ad-hoc bodies.
- Rollback: revert this PR to remove the template.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)