### PR TITLE
test: add parallel smoke script for phase-0 classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Output shape:
 }
 ```
 
+## Run smoke tests
+
+```bash
+./scripts/smoke_phase0.sh
+```
+
+This runs 3 classification smoke cases in parallel, captures each output separately, then prints section-wise results.
+
+By default, temporary smoke outputs are deleted after the run. Keep them for debugging with:
+
+```bash
+KEEP_SMOKE_LOGS=1 ./scripts/smoke_phase0.sh
+```
+
 ## Notes
 
 - Stage-1 timeout is fixed at 30 minutes.

--- a/devlogs.md
+++ b/devlogs.md
@@ -17,3 +17,9 @@
 - Added structured logging with stderr + file sinks at `logs/classify-pr.log`.
 - Added `LOGGING_LEVEL` support with default `warn` and optional `debug|info|warn|error`.
 - Added pipeline/stage-1/stage-2 logging for failures and fallback decisions.
+
+## 2026-03-11 - Smoke test runner
+
+- Added `scripts/smoke_phase0.sh` to run 3 classification smoke tests in parallel.
+- Captured each run to separate files, then printed section-wise output summaries.
+- Added auto-cleanup for smoke artifacts with optional `KEEP_SMOKE_LOGS=1` retention.

--- a/scripts/smoke_phase0.sh
+++ b/scripts/smoke_phase0.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_ID="$(date +%Y%m%d_%H%M%S)"
+RUN_DIR="${ROOT_DIR}/logs/smoke/run-${RUN_ID}"
+KEEP_SMOKE_LOGS="${KEEP_SMOKE_LOGS:-0}"
+
+CASE_NAMES=("reward_hub_64" "new_math_mnist_9" "invalid_issue_url")
+CASE_URLS=(
+  "https://github.com/Red-Hat-AI-Innovation-Team/reward_hub/pull/64"
+  "https://github.com/RohanAwhad/new-math-mnist/pull/9"
+  "https://github.com/RohanAwhad/new-math-mnist/issues/9"
+)
+CASE_EXPECTED=("no_human" "human_required" "human_required")
+
+cleanup() {
+  if [[ "${KEEP_SMOKE_LOGS}" != "1" ]]; then
+    rm -rf "${RUN_DIR}"
+  else
+    echo "kept smoke logs at ${RUN_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${RUN_DIR}"
+cd "${ROOT_DIR}"
+PIDS=()
+
+for i in "${!CASE_NAMES[@]}"; do
+  stdout_file="${RUN_DIR}/${CASE_NAMES[$i]}.stdout"
+  stderr_file="${RUN_DIR}/${CASE_NAMES[$i]}.stderr"
+  status_file="${RUN_DIR}/${CASE_NAMES[$i]}.exit"
+  (
+    go run ./cmd/classify-pr "${CASE_URLS[$i]}" >"${stdout_file}" 2>"${stderr_file}"
+    echo "$?" >"${status_file}"
+    exit 0
+  ) &
+  PIDS+=("$!")
+done
+
+for pid in "${PIDS[@]}"; do wait "${pid}"; done
+
+pass_count=0
+mismatch_count=0
+error_count=0
+
+for i in "${!CASE_NAMES[@]}"; do
+  name="${CASE_NAMES[$i]}"
+  expected="${CASE_EXPECTED[$i]}"
+  stdout_file="${RUN_DIR}/${name}.stdout"
+  stderr_file="${RUN_DIR}/${name}.stderr"
+  status_file="${RUN_DIR}/${name}.exit"
+  actual=""
+  status=""
+
+  if [[ ! -f "${status_file}" ]]; then
+    status="ERROR"
+    actual="missing-exit-code"
+    ((error_count+=1))
+  elif [[ "$(cat "${status_file}")" != "0" ]]; then
+    status="ERROR"
+    actual="command-failed"
+    ((error_count+=1))
+  else
+    actual="$(jq -r '.classification // empty' "${stdout_file}" 2>/dev/null || true)"
+    if [[ -z "${actual}" ]]; then
+      status="ERROR"
+      actual="invalid-json"
+      ((error_count+=1))
+    elif [[ "${actual}" == "${expected}" ]]; then
+      status="PASS"
+      ((pass_count+=1))
+    else
+      status="MISMATCH"
+      ((mismatch_count+=1))
+    fi
+  fi
+
+  echo "===== ${name} ====="
+  echo "URL: ${CASE_URLS[$i]}"
+  echo "Expected: ${expected}"
+  echo "Actual: ${actual}"
+  echo "Status: ${status}"
+  echo "--- Captured STDOUT ---"
+  cat "${stdout_file}"
+  echo "--- Captured STDERR ---"
+  cat "${stderr_file}"
+  echo
+done
+
+  echo "Summary: pass=${pass_count} mismatch=${mismatch_count} error=${error_count}"
+
+if [[ ${error_count} -gt 0 ]]; then exit 1; fi


### PR DESCRIPTION
## Why
- We need a repeatable smoke command for phase-0 classification without manually running each URL one by one.
- We need concurrent execution with per-case output capture so failures and mismatches are easy to inspect.

## Scope
- In:
  - Add a parallel bash smoke runner for the 3 agreed phase-0 cases.
  - Capture each case output separately and print section-wise summaries.
  - Document usage and retention behavior in README and devlogs.
- Out:
  - No changes to classification logic, prompts, or routing policy.
  - No CI wiring in this PR.

## Changes
- Add scripts/smoke_phase0.sh.
- Update README.md with smoke usage and KEEP_SMOKE_LOGS behavior.
- Update devlogs.md with the smoke runner milestone.

## Validation
- [x] go test ./... -> pass
- [x] ./scripts/smoke_phase0.sh -> runs all 3 cases in parallel and prints section-wise output
- [x] Manual check: KEEP_SMOKE_LOGS=1 preserves per-case files under logs/smoke/run-<timestamp>

## Risk
- Risk level: [x] Low [ ] Medium [ ] High
- Main risk: Parallel podman stage-1 runs can be resource heavy and may fallback to human_required if stage-1 is killed.
- Mitigation: Script is non-blocking for mismatches and only fails on hard infra/parse errors.
- Rollback: Revert this PR to remove smoke runner/docs changes.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)

## Test plan
- [x] Run Go package tests
- [x] Run smoke runner and confirm parallel execution + section-wise output
- [x] Validate each case has separate stdout/stderr capture files

## Test script

~~~python
from __future__ import annotations

import os
import shlex
import subprocess
from pathlib import Path


ROOT = Path(__file__).resolve().parent


def run(command: list[str], extra_env: dict[str, str] | None = None) -> None:
    print(f"$ {' '.join(shlex.quote(part) for part in command)}")
    env = os.environ.copy()
    if extra_env:
        env.update(extra_env)
    completed = subprocess.run(
        command,
        cwd=ROOT,
        env=env,
        text=True,
        capture_output=True,
        check=False,
    )
    if completed.stdout:
        print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
    if completed.stderr:
        print(completed.stderr, end="" if completed.stderr.endswith("\n") else "\n")
    print(f"[exit={completed.returncode}]")
    if completed.returncode != 0:
        raise SystemExit(completed.returncode)


def main() -> None:
    run(["go", "test", "./..."])
    run(["./scripts/smoke_phase0.sh"], {"KEEP_SMOKE_LOGS": "1"})


if __name__ == "__main__":
    main()
~~~

## Test output

~~~
$ go test ./...
?   	github.com/RohanAwhad/pr-review-bot/cmd/classify-pr	[no test files]
ok  	github.com/RohanAwhad/pr-review-bot/internal/classifier	(cached)
?   	github.com/RohanAwhad/pr-review-bot/internal/logging	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/normalize	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/pipeline	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/stage1	[no test files]
[exit=0]
$ ./scripts/smoke_phase0.sh
===== reward_hub_64 =====
URL: https://github.com/Red-Hat-AI-Innovation-Team/reward_hub/pull/64
Expected: no_human
Actual: human_required
Status: MISMATCH
--- Captured STDOUT ---
{
  "classification": "human_required",
  "confidence": 0,
  "reason": "stage-1 failed: run stage-1 container: exit status 137",
  "run_id": "run-1773211292-797128"
}
--- Captured STDERR ---
time=2026-03-11T02:41:38.998-04:00 level=ERROR msg="stage-1 podman run failed" component=classify-pr run_id=run-1773211292-797128 pr_url=https://github.com/Red-Hat-AI-Innovation-Team/reward_hub/pull/64 owner=Red-Hat-AI-Innovation-Team repo=reward_hub pr_number=64 error="exit status 137" output="Performing one time database migration, may take a few minutes...\nsqlite-migration:done\nDatabase migration complete.\n"
time=2026-03-11T02:41:38.998-04:00 level=ERROR msg="stage-1 failed" component=classify-pr run_id=run-1773211292-797128 pr_url=https://github.com/Red-Hat-AI-Innovation-Team/reward_hub/pull/64 error="run stage-1 container: exit status 137"

===== new_math_mnist_9 =====
URL: https://github.com/RohanAwhad/new-math-mnist/pull/9
Expected: human_required
Actual: human_required
Status: PASS
--- Captured STDOUT ---
{
  "classification": "human_required",
  "confidence": 0.85,
  "reason": "Backward-incompatible package restructuring that permanently removes top-level imports, defines a new public API surface, and changes the build system requires human sign-off on these architectural decisions. Specific concerns: (1) Breaking change - top-level imports removed with no deprecation path; (2) Public API design - __all__ list locks package contract; (3) Build system change - setuptools backend + editable install affects packaging; (4) Test assertions drift in test_prompts.py; (5) Difficulty level documentation changed in README without clear context.",
  "run_id": "run-1773211292-229012"
}
--- Captured STDERR ---

===== invalid_issue_url =====
URL: https://github.com/RohanAwhad/new-math-mnist/issues/9
Expected: human_required
Actual: human_required
Status: PASS
--- Captured STDOUT ---
{
  "classification": "human_required",
  "confidence": 0,
  "reason": "invalid pr url: invalid PR URL path: /RohanAwhad/new-math-mnist/issues/9",
  "run_id": "run-1773211292-837566"
}
--- Captured STDERR ---
time=2026-03-11T02:41:32.817-04:00 level=ERROR msg="parse PR URL failed" component=classify-pr run_id=run-1773211292-837566 pr_url=https://github.com/RohanAwhad/new-math-mnist/issues/9 error="invalid PR URL path: /RohanAwhad/new-math-mnist/issues/9"

Summary: pass=2 mismatch=1 error=0
kept smoke logs at /Users/rawhad/1_Projects/personal_projects/pr_review_bot_worktrees/smoke_tes/logs/smoke/run-20260311_024132
[exit=0]
~~~

## Unit tests

~~~
$ go test ./...
?   	github.com/RohanAwhad/pr-review-bot/cmd/classify-pr	[no test files]
ok  	github.com/RohanAwhad/pr-review-bot/internal/classifier	(cached)
?   	github.com/RohanAwhad/pr-review-bot/internal/logging	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/normalize	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/pipeline	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/stage1	[no test files]
~~~