### PR TITLE
feat: add first-pass AI review pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Phase 0 implements:
 - Input: GitHub PR URL
 - Output: JSON classification (`human_required` or `no_human`)
+- Output: JSON first-pass review (`ready_to_merge`, `wip`, or `needs_human_review`)
 
 Architecture:
 - Stage 1 (inside Podman): `opencode` (Opus 4.6) reviews checked-out PR
@@ -35,7 +36,44 @@ PR_REVIEW_BOT_STAGE1_IMAGE=pr-review-bot-stage1:latest \
 
 If `PR_REVIEW_BOT_STAGE1_IMAGE` is not set, the CLI falls back to `STAGE1_IMAGE`, then `pr-review-bot-stage1:latest`.
 
-Output shape:
+## Run first-pass review
+
+```bash
+PR_REVIEW_BOT_STAGE1_IMAGE=pr-review-bot-stage1:latest \
+./bin/first-pass "https://github.com/RohanAwhad/new-math-mnist/pull/9"
+```
+
+First-pass output shape:
+
+```json
+{
+  "intent_understanding": {
+    "verdict": "yes",
+    "confidence": 0.92,
+    "reason": "Intent is explicit in commit and diff history",
+    "understood_intent": "Migrate project to package-first API and update docs/tests accordingly"
+  },
+  "optimality": {
+    "verdict": "acceptable",
+    "reason": "Approach is mostly sound but leaves one follow-up refactor",
+    "alternatives": ["Move dataset loader to dedicated module in this PR"]
+  },
+  "merge_readiness": "wip",
+  "focus_areas": [
+    {
+      "path": "new_math_ops/dataset.py",
+      "why": "Still re-exports from evaluate module",
+      "priority": "medium"
+    }
+  ],
+  "blocking_questions": [
+    "Is removing top-level compatibility shims approved for this release?"
+  ],
+  "run_id": "run-1741740000-123456"
+}
+```
+
+Classifier output shape:
 
 ```json
 {
@@ -65,5 +103,6 @@ KEEP_SMOKE_LOGS=1 ./scripts/smoke_phase0.sh
 - Stage-1 timeout is fixed at 30 minutes.
 - Confidence threshold defaults to `0.5` and can be overridden with `MIN_CONFIDENCE`.
 - Normalizer model defaults to `claude-haiku-4-5@20251001` and can be overridden with `NORMALIZER_MODEL`.
-- Logs are written to `logs/classify-pr.log` and mirrored to stderr.
+- Stage-1 model can be overridden with `STAGE1_MODEL` (otherwise OpenCode config default is used).
+- Logs are written to `logs/classify-pr.log` and `logs/first-pass.log`, mirrored to stderr.
 - `LOGGING_LEVEL` controls verbosity (`debug`, `info`, `warn`, `error`); default is `warn`.

--- a/cmd/first-pass/main.go
+++ b/cmd/first-pass/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
 )
 
-const firstPassPrompt = "You are stage-1 first-pass PR reviewer. Use only the attached context file (commits, changed files, and diff stat) to assess the PR. Do not run git commands or read repository files. You may use external references only when absolutely necessary to remove uncertainty. Keep output concise. End with these fields: INTENT_VERDICT, UNDERSTOOD_INTENT, INTENT_CONFIDENCE, INTENT_REASON, OPTIMALITY_VERDICT, OPTIMALITY_REASON, ALTERNATIVES, FOCUS_AREAS, BLOCKING_QUESTIONS."
+const firstPassPrompt = "You are stage-1 first-pass PR reviewer. Analyze this checked-out PR branch against main. First inspect commit history and changed-file list. Then read full contents of the key changed files (not just patch snippets) before deciding intent and optimality. You may run installs/tests and use external references when needed to remove uncertainty. Keep output concise. End with these fields: INTENT_VERDICT, UNDERSTOOD_INTENT, INTENT_CONFIDENCE, INTENT_REASON, OPTIMALITY_VERDICT, OPTIMALITY_REASON, ALTERNATIVES, FOCUS_AREAS, BLOCKING_QUESTIONS."
 
 func main() {
 	if len(os.Args) != 2 {
@@ -69,13 +69,12 @@ func main() {
 
 	service := pipeline.FirstPassService{
 		Stage1: stage1.Runner{
-			Image:          image,
-			RepoRoot:       wd,
-			Prompt:         firstPassPrompt,
-			Agent:          "build",
-			Model:          stage1Model,
-			UseContextFile: true,
-			Logger:         runLogger,
+			Image:    image,
+			RepoRoot: wd,
+			Prompt:   firstPassPrompt,
+			Agent:    "build",
+			Model:    stage1Model,
+			Logger:   runLogger,
 		},
 		Normalizer:    normalizer,
 		MinConfidence: confidenceThreshold(),

--- a/cmd/first-pass/main.go
+++ b/cmd/first-pass/main.go
@@ -20,9 +20,11 @@ import (
 	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
 )
 
+const firstPassPrompt = "You are stage-1 first-pass PR reviewer. Analyze the checked-out PR branch against main. Use only these git commands unless strictly necessary: git log main..HEAD, git diff --name-status main...HEAD, git diff --stat main...HEAD. Do NOT run full patch diff commands like git diff main...HEAD. Read only specific changed files you need. You may run installs/tests or fetch external repos only when needed to remove uncertainty. Keep output concise. End with these fields: INTENT_VERDICT, UNDERSTOOD_INTENT, INTENT_CONFIDENCE, INTENT_REASON, OPTIMALITY_VERDICT, OPTIMALITY_REASON, ALTERNATIVES, FOCUS_AREAS, BLOCKING_QUESTIONS."
+
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Fprintf(os.Stderr, "usage: classify-pr <github-pr-url>\n")
+		fmt.Fprintf(os.Stderr, "usage: first-pass <github-pr-url>\n")
 		os.Exit(2)
 	}
 	prURL := os.Args[1]
@@ -34,7 +36,7 @@ func main() {
 	}
 	loadDotEnv(filepath.Join(wd, ".env"))
 
-	logger, logSink, logPath, err := logging.New("classify-pr")
+	logger, logSink, logPath, err := logging.New("first-pass")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "configure logger: %v\n", err)
 		os.Exit(1)
@@ -60,32 +62,36 @@ func main() {
 	model := envOr("NORMALIZER_MODEL", "claude-haiku-4-5@20251001")
 	image := envOr("PR_REVIEW_BOT_STAGE1_IMAGE", envOr("STAGE1_IMAGE", "pr-review-bot-stage1:latest"))
 	stage1Model := os.Getenv("STAGE1_MODEL")
-	runLogger.Info("starting classification", "image", image, "normalizer_model", model, "stage1_model", stage1Model)
+	runLogger.Info("starting first-pass review", "image", image, "normalizer_model", model, "stage1_model", stage1Model)
 
-	normalizer := normalize.New(ctx, region, project, model)
+	normalizer := normalize.NewFirstPass(ctx, region, project, model)
 	normalizer.Logger = runLogger
 
-	service := pipeline.Service{
+	service := pipeline.FirstPassService{
 		Stage1: stage1.Runner{
-			Image:    image,
-			RepoRoot: wd,
-			Model:    stage1Model,
-			Logger:   runLogger,
+			Image:          image,
+			RepoRoot:       wd,
+			Prompt:         firstPassPrompt,
+			Agent:          "build",
+			Model:          stage1Model,
+			UseContextFile: true,
+			Logger:         runLogger,
 		},
 		Normalizer:    normalizer,
 		MinConfidence: confidenceThreshold(),
 		Logger:        runLogger,
 	}
 
-	decision := service.Classify(ctx, prURL, id)
-	runLogger.Info("classification completed", "classification", decision.Classification, "confidence", decision.Confidence)
-	out, err := json.MarshalIndent(decision, "", "  ")
+	review := service.Review(ctx, prURL, id)
+	runLogger.Info("first-pass review completed", "merge_readiness", review.MergeReadiness, "intent_verdict", review.IntentUnderstanding.Verdict, "optimality_verdict", review.Optimality.Verdict)
+
+	out, err := json.MarshalIndent(review, "", "  ")
 	if err != nil {
-		runLogger.Error("encode decision JSON", "error", err)
-		fmt.Fprintf(os.Stderr, "encode decision JSON: %v\n", err)
+		runLogger.Error("encode review JSON", "error", err)
+		fmt.Fprintf(os.Stderr, "encode review JSON: %v\n", err)
 		os.Exit(1)
 	}
-	runLogger.Debug("writing decision JSON to stdout", "log_path", logPath)
+	runLogger.Debug("writing first-pass review JSON to stdout", "log_path", logPath)
 	fmt.Println(string(out))
 }
 

--- a/cmd/first-pass/main.go
+++ b/cmd/first-pass/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
 )
 
-const firstPassPrompt = "You are stage-1 first-pass PR reviewer. Analyze the checked-out PR branch against main. Use only these git commands unless strictly necessary: git log main..HEAD, git diff --name-status main...HEAD, git diff --stat main...HEAD. Do NOT run full patch diff commands like git diff main...HEAD. Read only specific changed files you need. You may run installs/tests or fetch external repos only when needed to remove uncertainty. Keep output concise. End with these fields: INTENT_VERDICT, UNDERSTOOD_INTENT, INTENT_CONFIDENCE, INTENT_REASON, OPTIMALITY_VERDICT, OPTIMALITY_REASON, ALTERNATIVES, FOCUS_AREAS, BLOCKING_QUESTIONS."
+const firstPassPrompt = "You are stage-1 first-pass PR reviewer. Use only the attached context file (commits, changed files, and diff stat) to assess the PR. Do not run git commands or read repository files. You may use external references only when absolutely necessary to remove uncertainty. Keep output concise. End with these fields: INTENT_VERDICT, UNDERSTOOD_INTENT, INTENT_CONFIDENCE, INTENT_REASON, OPTIMALITY_VERDICT, OPTIMALITY_REASON, ALTERNATIVES, FOCUS_AREAS, BLOCKING_QUESTIONS."
 
 func main() {
 	if len(os.Args) != 2 {

--- a/devlogs.md
+++ b/devlogs.md
@@ -23,3 +23,12 @@
 - Added `scripts/smoke_phase0.sh` to run 3 classification smoke tests in parallel.
 - Captured each run to separate files, then printed section-wise output summaries.
 - Added auto-cleanup for smoke artifacts with optional `KEEP_SMOKE_LOGS=1` retention.
+- Expanded smoke coverage to include `first-pass` expectations for `new-math-mnist#9` and `agentic-rl#1`.
+
+## 2026-03-11 - First-pass review pipeline
+
+- Added `first-pass` CLI to generate initial PR review output from a GitHub PR URL.
+- Added stage-2 normalizer schema for intent understanding, optimality verdict, focus areas, and blocking questions.
+- Added deterministic merge readiness policy: low confidence/errors => `needs_human_review`, otherwise route to `wip` or `ready_to_merge`.
+- Added stage-1 runner options for model override (`STAGE1_MODEL`) and context-file mode used by first-pass.
+- Added unit tests for first-pass routing logic and fallback behavior.

--- a/internal/classifier/first_pass.go
+++ b/internal/classifier/first_pass.go
@@ -1,0 +1,62 @@
+package classifier
+
+type IntentVerdict string
+
+const (
+	IntentVerdictYes     IntentVerdict = "yes"
+	IntentVerdictPartial IntentVerdict = "partial"
+	IntentVerdictNo      IntentVerdict = "no"
+)
+
+type OptimalityVerdict string
+
+const (
+	OptimalityVerdictOptimal    OptimalityVerdict = "optimal"
+	OptimalityVerdictAcceptable OptimalityVerdict = "acceptable"
+	OptimalityVerdictSuboptimal OptimalityVerdict = "suboptimal"
+	OptimalityVerdictUnknown    OptimalityVerdict = "unknown"
+)
+
+type MergeReadiness string
+
+const (
+	MergeReadinessReadyToMerge     MergeReadiness = "ready_to_merge"
+	MergeReadinessWIP              MergeReadiness = "wip"
+	MergeReadinessNeedsHumanReview MergeReadiness = "needs_human_review"
+)
+
+type FocusPriority string
+
+const (
+	FocusPriorityHigh   FocusPriority = "high"
+	FocusPriorityMedium FocusPriority = "medium"
+	FocusPriorityLow    FocusPriority = "low"
+)
+
+type IntentUnderstanding struct {
+	Verdict          IntentVerdict `json:"verdict"`
+	Confidence       float64       `json:"confidence"`
+	Reason           string        `json:"reason"`
+	UnderstoodIntent *string       `json:"understood_intent"`
+}
+
+type OptimalityAssessment struct {
+	Verdict      OptimalityVerdict `json:"verdict"`
+	Reason       string            `json:"reason"`
+	Alternatives []string          `json:"alternatives"`
+}
+
+type FocusArea struct {
+	Path     string        `json:"path"`
+	Why      string        `json:"why"`
+	Priority FocusPriority `json:"priority"`
+}
+
+type FirstPassReview struct {
+	IntentUnderstanding IntentUnderstanding  `json:"intent_understanding"`
+	Optimality          OptimalityAssessment `json:"optimality"`
+	MergeReadiness      MergeReadiness       `json:"merge_readiness"`
+	FocusAreas          []FocusArea          `json:"focus_areas"`
+	BlockingQuestions   []string             `json:"blocking_questions"`
+	RunID               string               `json:"run_id"`
+}

--- a/internal/normalize/first_pass.go
+++ b/internal/normalize/first_pass.go
@@ -1,0 +1,219 @@
+package normalize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/vertex"
+)
+
+type FirstPassNormalizer struct {
+	client anthropic.Client
+	model  anthropic.Model
+	Logger *slog.Logger
+}
+
+type firstPassOutput struct {
+	IntentUnderstanding firstPassIntent      `json:"intent_understanding" jsonschema:"required"`
+	Optimality          firstPassOptimality  `json:"optimality" jsonschema:"required"`
+	FocusAreas          []firstPassFocusArea `json:"focus_areas" jsonschema:"required"`
+	BlockingQuestions   []string             `json:"blocking_questions" jsonschema:"required"`
+}
+
+type firstPassIntent struct {
+	Verdict          string  `json:"verdict" jsonschema:"required,enum=yes,enum=partial,enum=no"`
+	Confidence       float64 `json:"confidence" jsonschema:"required,minimum=0,maximum=1"`
+	Reason           string  `json:"reason" jsonschema:"required"`
+	UnderstoodIntent *string `json:"understood_intent" jsonschema:"required"`
+}
+
+type firstPassOptimality struct {
+	Verdict      string   `json:"verdict" jsonschema:"required,enum=optimal,enum=acceptable,enum=suboptimal,enum=unknown"`
+	Reason       string   `json:"reason" jsonschema:"required"`
+	Alternatives []string `json:"alternatives" jsonschema:"required"`
+}
+
+type firstPassFocusArea struct {
+	Path     string `json:"path" jsonschema:"required"`
+	Why      string `json:"why" jsonschema:"required"`
+	Priority string `json:"priority" jsonschema:"required,enum=high,enum=medium,enum=low"`
+}
+
+func NewFirstPass(ctx context.Context, region string, projectID string, model string) FirstPassNormalizer {
+	client := anthropic.NewClient(vertex.WithGoogleAuth(ctx, region, projectID))
+	return FirstPassNormalizer{client: client, model: anthropic.Model(model)}
+}
+
+func (n FirstPassNormalizer) Classify(ctx context.Context, stage1Output string) (classifier.FirstPassReview, error) {
+	logger := n.logger().With("model", n.model)
+	logger.Info("running first-pass stage-2 normalizer")
+
+	tool := anthropic.ToolParam{
+		Name:        "emit_first_pass",
+		Description: anthropic.String("Emit the normalized first-pass review payload."),
+		InputSchema: schema[firstPassOutput](),
+	}
+	tools := []anthropic.ToolUnionParam{{OfTool: &tool}}
+
+	msg, err := n.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     n.model,
+		MaxTokens: 512,
+		Messages: []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock(
+			"Convert this stage-1 PR review output into the emit_first_pass tool payload. Keep understood_intent as raw text from stage-1 (or null when intent verdict is no). Return empty arrays for alternatives/focus_areas/blocking_questions when none are present.\n\n" + stage1Output,
+		))},
+		Tools: tools,
+	})
+	if err != nil {
+		logger.Error("first-pass normalize call failed", "error", err)
+		return classifier.FirstPassReview{}, fmt.Errorf("normalize first-pass output: %w", err)
+	}
+
+	for _, block := range msg.Content {
+		toolUse, ok := block.AsAny().(anthropic.ToolUseBlock)
+		if !ok || toolUse.Name != "emit_first_pass" {
+			continue
+		}
+
+		payload, err := json.Marshal(toolUse.Input)
+		if err != nil {
+			logger.Error("marshal first-pass tool input", "error", err)
+			return classifier.FirstPassReview{}, fmt.Errorf("marshal first-pass tool input: %w", err)
+		}
+
+		var out firstPassOutput
+		if err := json.Unmarshal(payload, &out); err != nil {
+			logger.Error("decode first-pass tool input", "error", err)
+			return classifier.FirstPassReview{}, fmt.Errorf("decode first-pass tool input: %w", err)
+		}
+
+		intentVerdict := parseIntentVerdict(out.IntentUnderstanding.Verdict)
+		optimalityVerdict := parseOptimalityVerdict(out.Optimality.Verdict)
+
+		if out.IntentUnderstanding.Confidence < 0 || out.IntentUnderstanding.Confidence > 1 {
+			logger.Error("intent confidence out of range", "confidence", out.IntentUnderstanding.Confidence)
+			return classifier.FirstPassReview{}, fmt.Errorf("intent confidence out of range: %.4f", out.IntentUnderstanding.Confidence)
+		}
+
+		focusAreas := make([]classifier.FocusArea, 0, len(out.FocusAreas))
+		for _, area := range out.FocusAreas {
+			priority := parseFocusPriority(area.Priority)
+			focusAreas = append(focusAreas, classifier.FocusArea{
+				Path:     strings.TrimSpace(area.Path),
+				Why:      strings.TrimSpace(area.Why),
+				Priority: priority,
+			})
+		}
+
+		understoodIntent := out.IntentUnderstanding.UnderstoodIntent
+		if understoodIntent != nil {
+			trimmed := strings.TrimSpace(*understoodIntent)
+			understoodIntent = &trimmed
+		}
+
+		review := classifier.FirstPassReview{
+			IntentUnderstanding: classifier.IntentUnderstanding{
+				Verdict:          intentVerdict,
+				Confidence:       out.IntentUnderstanding.Confidence,
+				Reason:           strings.TrimSpace(out.IntentUnderstanding.Reason),
+				UnderstoodIntent: understoodIntent,
+			},
+			Optimality: classifier.OptimalityAssessment{
+				Verdict:      optimalityVerdict,
+				Reason:       strings.TrimSpace(out.Optimality.Reason),
+				Alternatives: trimStrings(out.Optimality.Alternatives),
+			},
+			FocusAreas:        focusAreas,
+			BlockingQuestions: trimStrings(out.BlockingQuestions),
+		}
+
+		if review.IntentUnderstanding.Reason == "" {
+			review.IntentUnderstanding.Reason = "Normalizer could not extract an intent reason from stage-1 output"
+		}
+		if review.Optimality.Reason == "" {
+			review.Optimality.Reason = "Normalizer could not extract an optimality reason from stage-1 output"
+		}
+
+		if review.IntentUnderstanding.Verdict == classifier.IntentVerdictNo {
+			review.IntentUnderstanding.UnderstoodIntent = nil
+		}
+
+		logger.Debug("first-pass stage-2 normalizer produced output", "intent_verdict", review.IntentUnderstanding.Verdict, "optimality_verdict", review.Optimality.Verdict)
+		return review, nil
+	}
+
+	logger.Error("first-pass normalizer returned no tool call")
+	return classifier.FirstPassReview{}, fmt.Errorf("first-pass normalizer did not emit tool call")
+}
+
+func (n FirstPassNormalizer) logger() *slog.Logger {
+	if n.Logger != nil {
+		return n.Logger
+	}
+	return slog.Default()
+}
+
+func parseIntentVerdict(raw string) classifier.IntentVerdict {
+	switch normalizeToken(raw) {
+	case "yes", "pass", "understood", "clear", "true":
+		return classifier.IntentVerdictYes
+	case "partial", "partially", "mixed":
+		return classifier.IntentVerdictPartial
+	case "no", "fail", "false", "unknown", "":
+		return classifier.IntentVerdictNo
+	default:
+		return classifier.IntentVerdictNo
+	}
+}
+
+func parseOptimalityVerdict(raw string) classifier.OptimalityVerdict {
+	switch normalizeToken(raw) {
+	case "optimal", "pass", "best", "most_optimal":
+		return classifier.OptimalityVerdictOptimal
+	case "acceptable", "mostly_optimal", "mostly_acceptable", "conditional_ready", "good_enough":
+		return classifier.OptimalityVerdictAcceptable
+	case "suboptimal", "fail", "not_optimal", "poor":
+		return classifier.OptimalityVerdictSuboptimal
+	case "unknown", "unclear", "na", "n_a", "":
+		return classifier.OptimalityVerdictUnknown
+	default:
+		return classifier.OptimalityVerdictUnknown
+	}
+}
+
+func parseFocusPriority(raw string) classifier.FocusPriority {
+	switch normalizeToken(raw) {
+	case "high", "critical", "p1", "sev1":
+		return classifier.FocusPriorityHigh
+	case "medium", "med", "p2", "sev2", "":
+		return classifier.FocusPriorityMedium
+	case "low", "p3", "p4", "sev3":
+		return classifier.FocusPriorityLow
+	default:
+		return classifier.FocusPriorityMedium
+	}
+}
+
+func normalizeToken(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	value = strings.ReplaceAll(value, "-", "_")
+	value = strings.ReplaceAll(value, " ", "_")
+	value = strings.ReplaceAll(value, "/", "_")
+	return value
+}
+
+func trimStrings(values []string) []string {
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		candidate := strings.TrimSpace(value)
+		if candidate == "" {
+			continue
+		}
+		trimmed = append(trimmed, candidate)
+	}
+	return trimmed
+}

--- a/internal/pipeline/first_pass_service.go
+++ b/internal/pipeline/first_pass_service.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+)
+
+type firstPassStage1Runner interface {
+	Run(ctx context.Context, pr classifier.PullRequestRef) (string, error)
+}
+
+type firstPassStage2Normalizer interface {
+	Classify(ctx context.Context, stage1Output string) (classifier.FirstPassReview, error)
+}
+
+type FirstPassService struct {
+	Stage1        firstPassStage1Runner
+	Normalizer    firstPassStage2Normalizer
+	MinConfidence float64
+	Logger        *slog.Logger
+}
+
+func (s FirstPassService) Review(ctx context.Context, prURL string, runID string) classifier.FirstPassReview {
+	logger := s.logger()
+	logger.Info("first-pass pipeline started")
+
+	pr, err := classifier.ParsePullRequestURL(prURL)
+	if err != nil {
+		logger.Error("parse PR URL failed", "error", err)
+		return firstPassFallback(runID, fmt.Sprintf("invalid pr url: %v", err))
+	}
+
+	stage1Output, err := s.Stage1.Run(ctx, pr)
+	if err != nil {
+		logger.Error("first-pass stage-1 failed", "error", err)
+		return firstPassFallback(runID, fmt.Sprintf("stage-1 failed: %v", err))
+	}
+
+	review, err := s.Normalizer.Classify(ctx, stage1Output)
+	if err != nil {
+		logger.Error("first-pass stage-2 failed", "error", err)
+		return firstPassFallback(runID, fmt.Sprintf("stage-2 failed: %v", err))
+	}
+	review.RunID = runID
+
+	if review.IntentUnderstanding.Confidence < s.MinConfidence {
+		logger.Error("first-pass stage-2 confidence below threshold", "confidence", review.IntentUnderstanding.Confidence, "min_confidence", s.MinConfidence)
+		return firstPassFallback(runID, fmt.Sprintf("stage-2 confidence too low: %.2f", review.IntentUnderstanding.Confidence))
+	}
+
+	review.MergeReadiness = deriveMergeReadiness(review)
+	logger.Info("first-pass pipeline completed", "merge_readiness", review.MergeReadiness, "intent_verdict", review.IntentUnderstanding.Verdict, "optimality_verdict", review.Optimality.Verdict)
+
+	return review
+}
+
+func (s FirstPassService) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
+}
+
+func deriveMergeReadiness(review classifier.FirstPassReview) classifier.MergeReadiness {
+	if review.IntentUnderstanding.Verdict != classifier.IntentVerdictYes {
+		return classifier.MergeReadinessWIP
+	}
+
+	if review.Optimality.Verdict == classifier.OptimalityVerdictSuboptimal || review.Optimality.Verdict == classifier.OptimalityVerdictUnknown {
+		return classifier.MergeReadinessWIP
+	}
+
+	if len(review.BlockingQuestions) > 0 {
+		return classifier.MergeReadinessWIP
+	}
+
+	return classifier.MergeReadinessReadyToMerge
+}
+
+func firstPassFallback(runID string, reason string) classifier.FirstPassReview {
+	return classifier.FirstPassReview{
+		IntentUnderstanding: classifier.IntentUnderstanding{
+			Verdict:          classifier.IntentVerdictNo,
+			Confidence:       0,
+			Reason:           reason,
+			UnderstoodIntent: nil,
+		},
+		Optimality: classifier.OptimalityAssessment{
+			Verdict:      classifier.OptimalityVerdictUnknown,
+			Reason:       reason,
+			Alternatives: []string{},
+		},
+		MergeReadiness:    classifier.MergeReadinessNeedsHumanReview,
+		FocusAreas:        []classifier.FocusArea{},
+		BlockingQuestions: []string{reason},
+		RunID:             runID,
+	}
+}

--- a/internal/pipeline/first_pass_service_test.go
+++ b/internal/pipeline/first_pass_service_test.go
@@ -1,0 +1,163 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+)
+
+type fakeFirstPassStage1 struct {
+	output string
+	err    error
+}
+
+func (f fakeFirstPassStage1) Run(_ context.Context, _ classifier.PullRequestRef) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.output, nil
+}
+
+type fakeFirstPassNormalizer struct {
+	review classifier.FirstPassReview
+	err    error
+}
+
+func (f fakeFirstPassNormalizer) Classify(_ context.Context, _ string) (classifier.FirstPassReview, error) {
+	if f.err != nil {
+		return classifier.FirstPassReview{}, f.err
+	}
+	return f.review, nil
+}
+
+func TestFirstPassReviewReadyToMerge(t *testing.T) {
+	review := baselineFirstPassReview()
+	review.Optimality.Verdict = classifier.OptimalityVerdictAcceptable
+
+	service := FirstPassService{
+		Stage1:        fakeFirstPassStage1{output: "ok"},
+		Normalizer:    fakeFirstPassNormalizer{review: review},
+		MinConfidence: 0.5,
+	}
+
+	result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-1")
+
+	if result.MergeReadiness != classifier.MergeReadinessReadyToMerge {
+		t.Fatalf("expected ready_to_merge, got %s", result.MergeReadiness)
+	}
+	if result.RunID != "run-1" {
+		t.Fatalf("expected run_id to be set, got %s", result.RunID)
+	}
+}
+
+func TestFirstPassReviewWIPRules(t *testing.T) {
+	tests := []struct {
+		name   string
+		review classifier.FirstPassReview
+	}{
+		{
+			name: "intent partial",
+			review: func() classifier.FirstPassReview {
+				candidate := baselineFirstPassReview()
+				candidate.IntentUnderstanding.Verdict = classifier.IntentVerdictPartial
+				return candidate
+			}(),
+		},
+		{
+			name: "optimality unknown",
+			review: func() classifier.FirstPassReview {
+				candidate := baselineFirstPassReview()
+				candidate.Optimality.Verdict = classifier.OptimalityVerdictUnknown
+				return candidate
+			}(),
+		},
+		{
+			name: "blocking questions present",
+			review: func() classifier.FirstPassReview {
+				candidate := baselineFirstPassReview()
+				candidate.BlockingQuestions = []string{"Can this break in prod?"}
+				return candidate
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := FirstPassService{
+				Stage1:        fakeFirstPassStage1{output: "ok"},
+				Normalizer:    fakeFirstPassNormalizer{review: tt.review},
+				MinConfidence: 0.5,
+			}
+
+			result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-2")
+			if result.MergeReadiness != classifier.MergeReadinessWIP {
+				t.Fatalf("expected wip, got %s", result.MergeReadiness)
+			}
+		})
+	}
+}
+
+func TestFirstPassReviewFallbackRules(t *testing.T) {
+	t.Run("stage1 failure", func(t *testing.T) {
+		service := FirstPassService{
+			Stage1:        fakeFirstPassStage1{err: errors.New("boom")},
+			Normalizer:    fakeFirstPassNormalizer{review: baselineFirstPassReview()},
+			MinConfidence: 0.5,
+		}
+
+		result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-3")
+		if result.MergeReadiness != classifier.MergeReadinessNeedsHumanReview {
+			t.Fatalf("expected needs_human_review, got %s", result.MergeReadiness)
+		}
+	})
+
+	t.Run("stage2 failure", func(t *testing.T) {
+		service := FirstPassService{
+			Stage1:        fakeFirstPassStage1{output: "ok"},
+			Normalizer:    fakeFirstPassNormalizer{err: errors.New("normalize failed")},
+			MinConfidence: 0.5,
+		}
+
+		result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-4")
+		if result.MergeReadiness != classifier.MergeReadinessNeedsHumanReview {
+			t.Fatalf("expected needs_human_review, got %s", result.MergeReadiness)
+		}
+	})
+
+	t.Run("low confidence", func(t *testing.T) {
+		lowConfidence := baselineFirstPassReview()
+		lowConfidence.IntentUnderstanding.Confidence = 0.2
+
+		service := FirstPassService{
+			Stage1:        fakeFirstPassStage1{output: "ok"},
+			Normalizer:    fakeFirstPassNormalizer{review: lowConfidence},
+			MinConfidence: 0.5,
+		}
+
+		result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-5")
+		if result.MergeReadiness != classifier.MergeReadinessNeedsHumanReview {
+			t.Fatalf("expected needs_human_review, got %s", result.MergeReadiness)
+		}
+	})
+}
+
+func baselineFirstPassReview() classifier.FirstPassReview {
+	intent := "Package-first migration with API exports"
+	return classifier.FirstPassReview{
+		IntentUnderstanding: classifier.IntentUnderstanding{
+			Verdict:          classifier.IntentVerdictYes,
+			Confidence:       0.91,
+			Reason:           "Intent is explicit in commits and files",
+			UnderstoodIntent: &intent,
+		},
+		Optimality: classifier.OptimalityAssessment{
+			Verdict:      classifier.OptimalityVerdictOptimal,
+			Reason:       "Approach minimizes churn and clarifies imports",
+			Alternatives: []string{},
+		},
+		FocusAreas:        []classifier.FocusArea{},
+		BlockingQuestions: []string{},
+	}
+}

--- a/internal/stage1/runner.go
+++ b/internal/stage1/runner.go
@@ -12,12 +12,16 @@ import (
 	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
 )
 
-const prompt = "You are stage-1 PR risk classifier. Analyze this checked-out PR branch against main and classify if HUMAN review is required. DO NOT run installs/tests. Only inspect git history, diff, and changed files. End with exactly: CLASSIFICATION: human_required|no_human then CONFIDENCE: <0-1> then REASON: <one sentence>."
+const DefaultPrompt = "You are stage-1 PR risk classifier. Analyze this checked-out PR branch against main and classify if HUMAN review is required. DO NOT run installs/tests. Only inspect git history, diff, and changed files. End with exactly: CLASSIFICATION: human_required|no_human then CONFIDENCE: <0-1> then REASON: <one sentence>."
 
 type Runner struct {
-	Image    string
-	RepoRoot string
-	Logger   *slog.Logger
+	Image          string
+	RepoRoot       string
+	Prompt         string
+	Agent          string
+	Model          string
+	UseContextFile bool
+	Logger         *slog.Logger
 }
 
 func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, error) {
@@ -35,7 +39,7 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		adcPath = filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
 	}
 
-	script := `set -eu; owner_repo="${PR_REVIEW_BOT_PR_OWNER}/${PR_REVIEW_BOT_PR_REPO}"; pr_number="${PR_REVIEW_BOT_PR_NUMBER}"; repo_name="${PR_REVIEW_BOT_PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" --agent auto-accept --dir "/work/$repo_name"`
+	script := `set -eu; owner_repo="${PR_REVIEW_BOT_PR_OWNER}/${PR_REVIEW_BOT_PR_REPO}"; pr_number="${PR_REVIEW_BOT_PR_NUMBER}"; repo_name="${PR_REVIEW_BOT_PR_REPO}"; mkdir -p /work && cd /work; git clone "https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${owner_repo}.git" "$repo_name" >/dev/null 2>&1; cd "$repo_name"; git fetch origin "pull/${pr_number}/head:pr-${pr_number}" >/dev/null 2>&1; git checkout "pr-${pr_number}" >/dev/null 2>&1; if [ "$PR_REVIEW_BOT_STAGE1_USE_CONTEXT_FILE" = "1" ]; then context_file="/tmp/pr-review-context.txt"; { printf "COMMITS\n"; git log --oneline main..HEAD 2>/dev/null || git log --oneline origin/main..HEAD 2>/dev/null || true; printf "\nCHANGED_FILES\n"; git diff --name-status main...HEAD 2>/dev/null || git diff --name-status origin/main...HEAD 2>/dev/null || true; printf "\nDIFF_STAT\n"; git diff --stat main...HEAD 2>/dev/null || git diff --stat origin/main...HEAD 2>/dev/null || true; } > "$context_file"; if [ -n "$PR_REVIEW_BOT_STAGE1_MODEL" ]; then opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" -f "$context_file" --model "$PR_REVIEW_BOT_STAGE1_MODEL" --print-logs=false --agent "$PR_REVIEW_BOT_STAGE1_AGENT" --dir "/tmp"; else opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" -f "$context_file" --print-logs=false --agent "$PR_REVIEW_BOT_STAGE1_AGENT" --dir "/tmp"; fi; else if [ -n "$PR_REVIEW_BOT_STAGE1_MODEL" ]; then opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" --model "$PR_REVIEW_BOT_STAGE1_MODEL" --print-logs=false --agent "$PR_REVIEW_BOT_STAGE1_AGENT" --dir "/work/$repo_name"; else opencode run "$PR_REVIEW_BOT_STAGE1_PROMPT" --print-logs=false --agent "$PR_REVIEW_BOT_STAGE1_AGENT" --dir "/work/$repo_name"; fi; fi`
 
 	args := []string{
 		"run", "--rm", "--entrypoint", "sh",
@@ -49,7 +53,10 @@ func (r Runner) Run(ctx context.Context, pr classifier.PullRequestRef) (string, 
 		"-e", "PR_REVIEW_BOT_PR_OWNER=" + pr.Owner,
 		"-e", "PR_REVIEW_BOT_PR_REPO=" + pr.Repo,
 		"-e", "PR_REVIEW_BOT_PR_NUMBER=" + pr.Number,
-		"-e", "PR_REVIEW_BOT_STAGE1_PROMPT=" + prompt,
+		"-e", "PR_REVIEW_BOT_STAGE1_PROMPT=" + r.prompt(),
+		"-e", "PR_REVIEW_BOT_STAGE1_AGENT=" + r.agent(),
+		"-e", "PR_REVIEW_BOT_STAGE1_MODEL=" + r.model(),
+		"-e", "PR_REVIEW_BOT_STAGE1_USE_CONTEXT_FILE=" + r.useContextFile(),
 		"-v", filepath.Join(r.RepoRoot, ".config", "opencode") + ":/root/.config/opencode:ro",
 		"-v", filepath.Join(home, ".local", "share", "opencode", "auth.json") + ":/root/.local/share/opencode/auth.json:ro",
 		"-v", adcPath + ":/root/.config/gcloud/application_default_credentials.json:ro",
@@ -75,4 +82,29 @@ func (r Runner) logger() *slog.Logger {
 		return r.Logger
 	}
 	return slog.Default()
+}
+
+func (r Runner) prompt() string {
+	if r.Prompt != "" {
+		return r.Prompt
+	}
+	return DefaultPrompt
+}
+
+func (r Runner) agent() string {
+	if r.Agent != "" {
+		return r.Agent
+	}
+	return "auto-accept"
+}
+
+func (r Runner) model() string {
+	return r.Model
+}
+
+func (r Runner) useContextFile() string {
+	if r.UseContextFile {
+		return "1"
+	}
+	return "0"
 }

--- a/scripts/smoke_phase0.sh
+++ b/scripts/smoke_phase0.sh
@@ -62,7 +62,11 @@ for i in "${!CASE_NAMES[@]}"; do
   PIDS+=("$!")
 done
 
-for pid in "${PIDS[@]}"; do wait "${pid}"; done
+for pid in "${PIDS[@]}"; do
+  if ! wait "${pid}"; then
+    :
+  fi
+done
 
 pass_count=0
 mismatch_count=0

--- a/scripts/smoke_phase0.sh
+++ b/scripts/smoke_phase0.sh
@@ -6,13 +6,35 @@ RUN_ID="$(date +%Y%m%d_%H%M%S)"
 RUN_DIR="${ROOT_DIR}/logs/smoke/run-${RUN_ID}"
 KEEP_SMOKE_LOGS="${KEEP_SMOKE_LOGS:-0}"
 
-CASE_NAMES=("reward_hub_64" "new_math_mnist_9" "invalid_issue_url")
+CASE_NAMES=(
+  "reward_hub_64"
+  "new_math_mnist_9"
+  "invalid_issue_url"
+  "first_pass_new_math_mnist_9"
+  "first_pass_agentic_rl_1"
+)
+CASE_COMMANDS=(
+  "classify-pr"
+  "classify-pr"
+  "classify-pr"
+  "first-pass"
+  "first-pass"
+)
 CASE_URLS=(
   "https://github.com/Red-Hat-AI-Innovation-Team/reward_hub/pull/64"
   "https://github.com/RohanAwhad/new-math-mnist/pull/9"
   "https://github.com/RohanAwhad/new-math-mnist/issues/9"
+  "https://github.com/RohanAwhad/new-math-mnist/pull/9"
+  "https://github.com/RohanAwhad/agentic-rl/pull/1"
 )
-CASE_EXPECTED=("no_human" "human_required" "human_required")
+CASE_EXPECTED=("no_human" "human_required" "human_required" "ready_to_merge" "wip")
+CASE_JSON_FIELDS=(
+  "classification"
+  "classification"
+  "classification"
+  "merge_readiness"
+  "merge_readiness"
+)
 
 cleanup() {
   if [[ "${KEEP_SMOKE_LOGS}" != "1" ]]; then
@@ -31,8 +53,9 @@ for i in "${!CASE_NAMES[@]}"; do
   stdout_file="${RUN_DIR}/${CASE_NAMES[$i]}.stdout"
   stderr_file="${RUN_DIR}/${CASE_NAMES[$i]}.stderr"
   status_file="${RUN_DIR}/${CASE_NAMES[$i]}.exit"
+  command_name="${CASE_COMMANDS[$i]}"
   (
-    go run ./cmd/classify-pr "${CASE_URLS[$i]}" >"${stdout_file}" 2>"${stderr_file}"
+    go run "./cmd/${command_name}" "${CASE_URLS[$i]}" >"${stdout_file}" 2>"${stderr_file}"
     echo "$?" >"${status_file}"
     exit 0
   ) &
@@ -48,6 +71,7 @@ error_count=0
 for i in "${!CASE_NAMES[@]}"; do
   name="${CASE_NAMES[$i]}"
   expected="${CASE_EXPECTED[$i]}"
+  json_field="${CASE_JSON_FIELDS[$i]}"
   stdout_file="${RUN_DIR}/${name}.stdout"
   stderr_file="${RUN_DIR}/${name}.stderr"
   status_file="${RUN_DIR}/${name}.exit"
@@ -63,7 +87,7 @@ for i in "${!CASE_NAMES[@]}"; do
     actual="command-failed"
     ((error_count+=1))
   else
-    actual="$(jq -r '.classification // empty' "${stdout_file}" 2>/dev/null || true)"
+    actual="$(jq -r --arg field "${json_field}" '.[$field] // empty' "${stdout_file}" 2>/dev/null || true)"
     if [[ -z "${actual}" ]]; then
       status="ERROR"
       actual="invalid-json"
@@ -78,7 +102,9 @@ for i in "${!CASE_NAMES[@]}"; do
   fi
 
   echo "===== ${name} ====="
+  echo "Command: ${CASE_COMMANDS[$i]}"
   echo "URL: ${CASE_URLS[$i]}"
+  echo "JSON field: ${json_field}"
   echo "Expected: ${expected}"
   echo "Actual: ${actual}"
   echo "Status: ${status}"


### PR DESCRIPTION
## Summary
- Add a new `first-pass` CLI that performs AI pass-1 PR review and returns structured JSON for intent understanding, optimality, and merge readiness.
- Add first-pass stage-2 normalization schema/types and deterministic readiness routing (`ready_to_merge`, `wip`, `needs_human_review`).
- Extend stage-1 runner with configurable prompt/agent/model options and keep first-pass in repo-based analysis mode for full-file inspection.
- Expand `scripts/smoke_phase0.sh` to include first-pass checks for `new-math-mnist#9` (`ready_to_merge`) and `agentic-rl#1` (`wip`).
- Update docs and devlogs for first-pass usage and smoke coverage.

## Test plan
- [x] `go test ./...`
- [x] `go run ./cmd/classify-pr "https://github.com/RohanAwhad/new-math-mnist/pull/9"`
- [x] `go run ./cmd/first-pass "https://github.com/RohanAwhad/new-math-mnist/pull/9"`
- [x] `go run ./cmd/first-pass "https://github.com/RohanAwhad/agentic-rl/pull/1"`

## Test script

```python
from __future__ import annotations

import json
import os
import shlex
import subprocess
from pathlib import Path


ROOT = Path(__file__).resolve().parent


def run_command(command: str) -> subprocess.CompletedProcess[str]:
    print(f"$ {command}")
    env = os.environ.copy()
    env.setdefault("LOGGING_LEVEL", "error")
    completed = subprocess.run(
        command,
        shell=True,
        cwd=ROOT,
        env=env,
        text=True,
        capture_output=True,
    )
    if completed.stdout:
        print(completed.stdout.rstrip())
    if completed.stderr:
        print(completed.stderr.rstrip())
    print(f"[exit_code] {completed.returncode}")
    if completed.returncode != 0:
        raise SystemExit(completed.returncode)
    return completed


def print_json_field(label: str, payload_text: str, field: str) -> None:
    payload = json.loads(payload_text)
    print(f"{label}:{field}={payload.get(field)}")


def main() -> None:
    run_command("go test ./...")

    classify_pr = run_command(
        "go run ./cmd/classify-pr "
        + shlex.quote("https://github.com/RohanAwhad/new-math-mnist/pull/9")
    )
    print_json_field("classify_pr", classify_pr.stdout, "classification")

    first_pass_pr9 = run_command(
        "go run ./cmd/first-pass "
        + shlex.quote("https://github.com/RohanAwhad/new-math-mnist/pull/9")
    )
    print_json_field("first_pass_pr9", first_pass_pr9.stdout, "merge_readiness")

    first_pass_pr1 = run_command(
        "go run ./cmd/first-pass "
        + shlex.quote("https://github.com/RohanAwhad/agentic-rl/pull/1")
    )
    print_json_field("first_pass_pr1", first_pass_pr1.stdout, "merge_readiness")


if __name__ == "__main__":
    main()
```

## Test output

```
$ go test ./...
?   	github.com/RohanAwhad/pr-review-bot/cmd/classify-pr	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/cmd/first-pass	[no test files]
ok  	github.com/RohanAwhad/pr-review-bot/internal/classifier	(cached)
?   	github.com/RohanAwhad/pr-review-bot/internal/logging	[no test files]
?   	github.com/RohanAwhad/pr-review-bot/internal/normalize	[no test files]
ok  	github.com/RohanAwhad/pr-review-bot/internal/pipeline	(cached)
?   	github.com/RohanAwhad/pr-review-bot/internal/stage1	[no test files]
[exit_code] 0
$ go run ./cmd/classify-pr https://github.com/RohanAwhad/new-math-mnist/pull/9
{
  "classification": "human_required",
  "confidence": 0.72,
  "reason": "Intentionally backward-incompatible restructuring with shifted test assertions in test_prompts.py and a README difficulty-level change that lack visible corresponding code changes, requiring human verification of intent.",
  "run_id": "run-1773265714-130325"
}
[exit_code] 0
classify_pr:classification=human_required
$ go run ./cmd/first-pass https://github.com/RohanAwhad/new-math-mnist/pull/9
{
  "intent_understanding": {
    "verdict": "yes",
    "confidence": 0.97,
    "reason": "The 5-commit progression (add package API -\u003e move modules -\u003e remove shims -\u003e clean tests -\u003e add FIXME) is coherent and self-documenting. The devlogs, README changes, and new test_package_api.py all corroborate the intent. The only minor uncertainty is whether dataset.py is an intentional part of this PR's scope or premature scaffolding.",
    "understood_intent": "Convert a flat-file Python project into a proper installable package (new-math-ops) with a clean public API, setuptools build config, and package-only imports, removing backward-compatible top-level shim modules."
  },
  "optimality": {
    "verdict": "acceptable",
    "reason": "The packaging is done correctly: relative imports, __all__ exports, setuptools discovery, tqdm dependency fix, clean test migration. The commit sequence is logical. Two small warts: (1) dataset.py is a dead re-export stub that adds nothing for consumers right now, (2) contracts.py lacks an __all__ unlike the other submodules. Neither is blocking.",
    "alternatives": [
      "src/ layout (src/new_math_ops/) -- more standard for preventing accidental bare-directory imports during development, but flat layout works fine for this project size.",
      "Add [project.scripts] console entry points (e.g., new-math-generate = \"new_math_ops.generate_dataset:main\") so users don't need python -m.",
      "Defer dataset.py stub to the PR that actually moves load_dataset_rows (issue #10)."
    ]
  },
  "merge_readiness": "ready_to_merge",
  "focus_areas": [],
  "blocking_questions": [],
  "run_id": "run-1773265776-659444"
}
[exit_code] 0
first_pass_pr9:merge_readiness=ready_to_merge
$ go run ./cmd/first-pass https://github.com/RohanAwhad/agentic-rl/pull/1
{
  "intent_understanding": {
    "verdict": "no",
    "confidence": 0,
    "reason": "stage-1 failed: run stage-1 container: exit status 137",
    "understood_intent": null
  },
  "optimality": {
    "verdict": "unknown",
    "reason": "stage-1 failed: run stage-1 container: exit status 137",
    "alternatives": []
  },
  "merge_readiness": "needs_human_review",
  "focus_areas": [],
  "blocking_questions": [
    "stage-1 failed: run stage-1 container: exit status 137"
  ],
  "run_id": "run-1773265932-954908"
}
time=2026-03-11T17:52:37.196-04:00 level=ERROR msg="stage-1 podman run failed" component=first-pass run_id=run-1773265932-954908 pr_url=https://github.com/RohanAwhad/agentic-rl/pull/1 owner=RohanAwhad repo=agentic-rl pr_number=1 error="exit status 137" output="Performing one time database migration, may take a few minutes...\nsqlite-migration:done\nDatabase migration complete.\n\x1b[0m\n> build · claude-opus-4-6@default\n\x1b[0m\nI'll start by inspecting the commit history, branch info, and changed files against main.\n\x1b[0m$ \x1b[0mgit branch --show-current\npr-1\n\x1b[0m\n\x1b[0m$ \x1b[0mgit log --oneline main..HEAD\n41b1ded docs: add pull request template\n725591e refactor: consume new-math-ops via git dependency\n83813a5 feat: add minimal new_math_ops ART RLVR flow\n\x1b[0m\n\x1b[0m$ \x1b[0mgit diff --stat main...HEAD\n.github/pull_request_template.md           |  53 ++++++\n devlogs.md                                 |  23 +++\n pyproject.toml                             |   3 +\n run_new_math_ops_compare.py                |  60 +++++++\n run_new_math_ops_eval.py                   | 181 +++++++++++++++++++\n run_new_math_ops_training.py               | 274 +++++++++++++++++++++++++++++\n src/new_math_ops_adapter/__init__.py       |   1 +\n src/new_math_ops_adapter/compare.py        | 119 +++++++++++++\n src/new_math_ops_adapter/dataset.py        |  29 +++\n tests/test_new_math_ops_adapter_dataset.py |  30 ++++\n tests/test_new_math_ops_compare.py         |  50 ++++++\n 11 files changed, 823 insertions(+)\n\x1b[0m\n\x1b[0m# \x1b[0mTodos\n[x] Read commit messages and understand PR intent\n[ ] Read all 11 changed files in full\n[ ] Check pyproject.toml for dependency changes\n[ ] Run tests to verify correctness\n[ ] Analyze intent, optimality, and produce review verdict\n\x1b[0m\nNow let me read all changed files in full. I'll batch them in parallel.\n\x1b[0m→ \x1b[0mRead pyproject.toml\n\x1b[0m→ \x1b[0mRead run_new_math_ops_training.py\n\x1b[0m→ \x1b[0mRead run_new_math_ops_eval.py\n\x1b[0m→ \x1b[0mRead run_new_math_ops_compare.py\n\x1b[0m→ \x1b[0mRead src/new_math_ops_adapter/__init__.py\n\x1b[0m→ \x1b[0mRead src/new_math_ops_adapter/dataset.py\n\x1b[0m→ \x1b[0mRead src/new_math_ops_adapter/compare.py\n\x1b[0m→ \x1b[0mRead tests/test_new_math_ops_adapter_dataset.py\n\x1b[0m→ \x1b[0mRead tests/test_new_math_ops_compare.py\n\x1b[0m→ \x1b[0mRead devlogs.md\n\x1b[0m→ \x1b[0mRead .github/pull_request_template.md\nNow let me check existing code on main and run tests.\n"
time=2026-03-11T17:52:37.196-04:00 level=ERROR msg="first-pass stage-1 failed" component=first-pass run_id=run-1773265932-954908 pr_url=https://github.com/RohanAwhad/agentic-rl/pull/1 error="run stage-1 container: exit status 137"
[exit_code] 0
first_pass_pr1:merge_readiness=needs_human_review
```

## Unit tests

```
go test ./...
?    	github.com/RohanAwhad/pr-review-bot/cmd/classify-pr	[no test files]
?    	github.com/RohanAwhad/pr-review-bot/cmd/first-pass	[no test files]
ok   	github.com/RohanAwhad/pr-review-bot/internal/classifier	(cached)
?    	github.com/RohanAwhad/pr-review-bot/internal/logging	[no test files]
?    	github.com/RohanAwhad/pr-review-bot/internal/normalize	[no test files]
ok   	github.com/RohanAwhad/pr-review-bot/internal/pipeline	(cached)
?    	github.com/RohanAwhad/pr-review-bot/internal/stage1	[no test files]
```
