### PR TITLE
feat: add first-pass core contracts and routing

### DIFF
--- a/internal/classifier/first_pass.go
+++ b/internal/classifier/first_pass.go
@@ -1,0 +1,62 @@
+package classifier
+
+type IntentVerdict string
+
+const (
+	IntentVerdictYes     IntentVerdict = "yes"
+	IntentVerdictPartial IntentVerdict = "partial"
+	IntentVerdictNo      IntentVerdict = "no"
+)
+
+type OptimalityVerdict string
+
+const (
+	OptimalityVerdictOptimal    OptimalityVerdict = "optimal"
+	OptimalityVerdictAcceptable OptimalityVerdict = "acceptable"
+	OptimalityVerdictSuboptimal OptimalityVerdict = "suboptimal"
+	OptimalityVerdictUnknown    OptimalityVerdict = "unknown"
+)
+
+type MergeReadiness string
+
+const (
+	MergeReadinessReadyToMerge     MergeReadiness = "ready_to_merge"
+	MergeReadinessWIP              MergeReadiness = "wip"
+	MergeReadinessNeedsHumanReview MergeReadiness = "needs_human_review"
+)
+
+type FocusPriority string
+
+const (
+	FocusPriorityHigh   FocusPriority = "high"
+	FocusPriorityMedium FocusPriority = "medium"
+	FocusPriorityLow    FocusPriority = "low"
+)
+
+type IntentUnderstanding struct {
+	Verdict          IntentVerdict `json:"verdict"`
+	Confidence       float64       `json:"confidence"`
+	Reason           string        `json:"reason"`
+	UnderstoodIntent *string       `json:"understood_intent"`
+}
+
+type OptimalityAssessment struct {
+	Verdict      OptimalityVerdict `json:"verdict"`
+	Reason       string            `json:"reason"`
+	Alternatives []string          `json:"alternatives"`
+}
+
+type FocusArea struct {
+	Path     string        `json:"path"`
+	Why      string        `json:"why"`
+	Priority FocusPriority `json:"priority"`
+}
+
+type FirstPassReview struct {
+	IntentUnderstanding IntentUnderstanding  `json:"intent_understanding"`
+	Optimality          OptimalityAssessment `json:"optimality"`
+	MergeReadiness      MergeReadiness       `json:"merge_readiness"`
+	FocusAreas          []FocusArea          `json:"focus_areas"`
+	BlockingQuestions   []string             `json:"blocking_questions"`
+	RunID               string               `json:"run_id"`
+}

--- a/internal/normalize/first_pass.go
+++ b/internal/normalize/first_pass.go
@@ -1,0 +1,219 @@
+package normalize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/vertex"
+)
+
+type FirstPassNormalizer struct {
+	client anthropic.Client
+	model  anthropic.Model
+	Logger *slog.Logger
+}
+
+type firstPassOutput struct {
+	IntentUnderstanding firstPassIntent      `json:"intent_understanding" jsonschema:"required"`
+	Optimality          firstPassOptimality  `json:"optimality" jsonschema:"required"`
+	FocusAreas          []firstPassFocusArea `json:"focus_areas" jsonschema:"required"`
+	BlockingQuestions   []string             `json:"blocking_questions" jsonschema:"required"`
+}
+
+type firstPassIntent struct {
+	Verdict          string  `json:"verdict" jsonschema:"required,enum=yes,enum=partial,enum=no"`
+	Confidence       float64 `json:"confidence" jsonschema:"required,minimum=0,maximum=1"`
+	Reason           string  `json:"reason" jsonschema:"required"`
+	UnderstoodIntent *string `json:"understood_intent" jsonschema:"required"`
+}
+
+type firstPassOptimality struct {
+	Verdict      string   `json:"verdict" jsonschema:"required,enum=optimal,enum=acceptable,enum=suboptimal,enum=unknown"`
+	Reason       string   `json:"reason" jsonschema:"required"`
+	Alternatives []string `json:"alternatives" jsonschema:"required"`
+}
+
+type firstPassFocusArea struct {
+	Path     string `json:"path" jsonschema:"required"`
+	Why      string `json:"why" jsonschema:"required"`
+	Priority string `json:"priority" jsonschema:"required,enum=high,enum=medium,enum=low"`
+}
+
+func NewFirstPass(ctx context.Context, region string, projectID string, model string) FirstPassNormalizer {
+	client := anthropic.NewClient(vertex.WithGoogleAuth(ctx, region, projectID))
+	return FirstPassNormalizer{client: client, model: anthropic.Model(model)}
+}
+
+func (n FirstPassNormalizer) Classify(ctx context.Context, stage1Output string) (classifier.FirstPassReview, error) {
+	logger := n.logger().With("model", n.model)
+	logger.Info("running first-pass stage-2 normalizer")
+
+	tool := anthropic.ToolParam{
+		Name:        "emit_first_pass",
+		Description: anthropic.String("Emit the normalized first-pass review payload."),
+		InputSchema: schema[firstPassOutput](),
+	}
+	tools := []anthropic.ToolUnionParam{{OfTool: &tool}}
+
+	msg, err := n.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     n.model,
+		MaxTokens: 512,
+		Messages: []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock(
+			"Convert this stage-1 PR review output into the emit_first_pass tool payload. Keep understood_intent as raw text from stage-1 (or null when intent verdict is no). Return empty arrays for alternatives/focus_areas/blocking_questions when none are present.\n\n" + stage1Output,
+		))},
+		Tools: tools,
+	})
+	if err != nil {
+		logger.Error("first-pass normalize call failed", "error", err)
+		return classifier.FirstPassReview{}, fmt.Errorf("normalize first-pass output: %w", err)
+	}
+
+	for _, block := range msg.Content {
+		toolUse, ok := block.AsAny().(anthropic.ToolUseBlock)
+		if !ok || toolUse.Name != "emit_first_pass" {
+			continue
+		}
+
+		payload, err := json.Marshal(toolUse.Input)
+		if err != nil {
+			logger.Error("marshal first-pass tool input", "error", err)
+			return classifier.FirstPassReview{}, fmt.Errorf("marshal first-pass tool input: %w", err)
+		}
+
+		var out firstPassOutput
+		if err := json.Unmarshal(payload, &out); err != nil {
+			logger.Error("decode first-pass tool input", "error", err)
+			return classifier.FirstPassReview{}, fmt.Errorf("decode first-pass tool input: %w", err)
+		}
+
+		intentVerdict := parseIntentVerdict(out.IntentUnderstanding.Verdict)
+		optimalityVerdict := parseOptimalityVerdict(out.Optimality.Verdict)
+
+		if out.IntentUnderstanding.Confidence < 0 || out.IntentUnderstanding.Confidence > 1 {
+			logger.Error("intent confidence out of range", "confidence", out.IntentUnderstanding.Confidence)
+			return classifier.FirstPassReview{}, fmt.Errorf("intent confidence out of range: %.4f", out.IntentUnderstanding.Confidence)
+		}
+
+		focusAreas := make([]classifier.FocusArea, 0, len(out.FocusAreas))
+		for _, area := range out.FocusAreas {
+			priority := parseFocusPriority(area.Priority)
+			focusAreas = append(focusAreas, classifier.FocusArea{
+				Path:     strings.TrimSpace(area.Path),
+				Why:      strings.TrimSpace(area.Why),
+				Priority: priority,
+			})
+		}
+
+		understoodIntent := out.IntentUnderstanding.UnderstoodIntent
+		if understoodIntent != nil {
+			trimmed := strings.TrimSpace(*understoodIntent)
+			understoodIntent = &trimmed
+		}
+
+		review := classifier.FirstPassReview{
+			IntentUnderstanding: classifier.IntentUnderstanding{
+				Verdict:          intentVerdict,
+				Confidence:       out.IntentUnderstanding.Confidence,
+				Reason:           strings.TrimSpace(out.IntentUnderstanding.Reason),
+				UnderstoodIntent: understoodIntent,
+			},
+			Optimality: classifier.OptimalityAssessment{
+				Verdict:      optimalityVerdict,
+				Reason:       strings.TrimSpace(out.Optimality.Reason),
+				Alternatives: trimStrings(out.Optimality.Alternatives),
+			},
+			FocusAreas:        focusAreas,
+			BlockingQuestions: trimStrings(out.BlockingQuestions),
+		}
+
+		if review.IntentUnderstanding.Reason == "" {
+			review.IntentUnderstanding.Reason = "Normalizer could not extract an intent reason from stage-1 output"
+		}
+		if review.Optimality.Reason == "" {
+			review.Optimality.Reason = "Normalizer could not extract an optimality reason from stage-1 output"
+		}
+
+		if review.IntentUnderstanding.Verdict == classifier.IntentVerdictNo {
+			review.IntentUnderstanding.UnderstoodIntent = nil
+		}
+
+		logger.Debug("first-pass stage-2 normalizer produced output", "intent_verdict", review.IntentUnderstanding.Verdict, "optimality_verdict", review.Optimality.Verdict)
+		return review, nil
+	}
+
+	logger.Error("first-pass normalizer returned no tool call")
+	return classifier.FirstPassReview{}, fmt.Errorf("first-pass normalizer did not emit tool call")
+}
+
+func (n FirstPassNormalizer) logger() *slog.Logger {
+	if n.Logger != nil {
+		return n.Logger
+	}
+	return slog.Default()
+}
+
+func parseIntentVerdict(raw string) classifier.IntentVerdict {
+	switch normalizeToken(raw) {
+	case "yes", "pass", "understood", "clear", "true":
+		return classifier.IntentVerdictYes
+	case "partial", "partially", "mixed":
+		return classifier.IntentVerdictPartial
+	case "no", "fail", "false", "unknown", "":
+		return classifier.IntentVerdictNo
+	default:
+		return classifier.IntentVerdictNo
+	}
+}
+
+func parseOptimalityVerdict(raw string) classifier.OptimalityVerdict {
+	switch normalizeToken(raw) {
+	case "optimal", "pass", "best", "most_optimal":
+		return classifier.OptimalityVerdictOptimal
+	case "acceptable", "mostly_optimal", "mostly_acceptable", "conditional_ready", "good_enough":
+		return classifier.OptimalityVerdictAcceptable
+	case "suboptimal", "fail", "not_optimal", "poor":
+		return classifier.OptimalityVerdictSuboptimal
+	case "unknown", "unclear", "na", "n_a", "":
+		return classifier.OptimalityVerdictUnknown
+	default:
+		return classifier.OptimalityVerdictUnknown
+	}
+}
+
+func parseFocusPriority(raw string) classifier.FocusPriority {
+	switch normalizeToken(raw) {
+	case "high", "critical", "p1", "sev1":
+		return classifier.FocusPriorityHigh
+	case "medium", "med", "p2", "sev2", "":
+		return classifier.FocusPriorityMedium
+	case "low", "p3", "p4", "sev3":
+		return classifier.FocusPriorityLow
+	default:
+		return classifier.FocusPriorityMedium
+	}
+}
+
+func normalizeToken(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	value = strings.ReplaceAll(value, "-", "_")
+	value = strings.ReplaceAll(value, " ", "_")
+	value = strings.ReplaceAll(value, "/", "_")
+	return value
+}
+
+func trimStrings(values []string) []string {
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		candidate := strings.TrimSpace(value)
+		if candidate == "" {
+			continue
+		}
+		trimmed = append(trimmed, candidate)
+	}
+	return trimmed
+}

--- a/internal/pipeline/first_pass_service.go
+++ b/internal/pipeline/first_pass_service.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+)
+
+type firstPassStage1Runner interface {
+	Run(ctx context.Context, pr classifier.PullRequestRef) (string, error)
+}
+
+type firstPassStage2Normalizer interface {
+	Classify(ctx context.Context, stage1Output string) (classifier.FirstPassReview, error)
+}
+
+type FirstPassService struct {
+	Stage1        firstPassStage1Runner
+	Normalizer    firstPassStage2Normalizer
+	MinConfidence float64
+	Logger        *slog.Logger
+}
+
+func (s FirstPassService) Review(ctx context.Context, prURL string, runID string) classifier.FirstPassReview {
+	logger := s.logger()
+	logger.Info("first-pass pipeline started")
+
+	pr, err := classifier.ParsePullRequestURL(prURL)
+	if err != nil {
+		logger.Error("parse PR URL failed", "error", err)
+		return firstPassFallback(runID, fmt.Sprintf("invalid pr url: %v", err))
+	}
+
+	stage1Output, err := s.Stage1.Run(ctx, pr)
+	if err != nil {
+		logger.Error("first-pass stage-1 failed", "error", err)
+		return firstPassFallback(runID, fmt.Sprintf("stage-1 failed: %v", err))
+	}
+
+	review, err := s.Normalizer.Classify(ctx, stage1Output)
+	if err != nil {
+		logger.Error("first-pass stage-2 failed", "error", err)
+		return firstPassFallback(runID, fmt.Sprintf("stage-2 failed: %v", err))
+	}
+	review.RunID = runID
+
+	if review.IntentUnderstanding.Confidence < s.MinConfidence {
+		logger.Error("first-pass stage-2 confidence below threshold", "confidence", review.IntentUnderstanding.Confidence, "min_confidence", s.MinConfidence)
+		return firstPassFallback(runID, fmt.Sprintf("stage-2 confidence too low: %.2f", review.IntentUnderstanding.Confidence))
+	}
+
+	review.MergeReadiness = deriveMergeReadiness(review)
+	logger.Info("first-pass pipeline completed", "merge_readiness", review.MergeReadiness, "intent_verdict", review.IntentUnderstanding.Verdict, "optimality_verdict", review.Optimality.Verdict)
+
+	return review
+}
+
+func (s FirstPassService) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
+}
+
+func deriveMergeReadiness(review classifier.FirstPassReview) classifier.MergeReadiness {
+	if review.IntentUnderstanding.Verdict != classifier.IntentVerdictYes {
+		return classifier.MergeReadinessWIP
+	}
+
+	if review.Optimality.Verdict == classifier.OptimalityVerdictSuboptimal || review.Optimality.Verdict == classifier.OptimalityVerdictUnknown {
+		return classifier.MergeReadinessWIP
+	}
+
+	if len(review.BlockingQuestions) > 0 {
+		return classifier.MergeReadinessWIP
+	}
+
+	return classifier.MergeReadinessReadyToMerge
+}
+
+func firstPassFallback(runID string, reason string) classifier.FirstPassReview {
+	return classifier.FirstPassReview{
+		IntentUnderstanding: classifier.IntentUnderstanding{
+			Verdict:          classifier.IntentVerdictNo,
+			Confidence:       0,
+			Reason:           reason,
+			UnderstoodIntent: nil,
+		},
+		Optimality: classifier.OptimalityAssessment{
+			Verdict:      classifier.OptimalityVerdictUnknown,
+			Reason:       reason,
+			Alternatives: []string{},
+		},
+		MergeReadiness:    classifier.MergeReadinessNeedsHumanReview,
+		FocusAreas:        []classifier.FocusArea{},
+		BlockingQuestions: []string{reason},
+		RunID:             runID,
+	}
+}

--- a/internal/pipeline/first_pass_service_test.go
+++ b/internal/pipeline/first_pass_service_test.go
@@ -1,0 +1,163 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/classifier"
+)
+
+type fakeFirstPassStage1 struct {
+	output string
+	err    error
+}
+
+func (f fakeFirstPassStage1) Run(_ context.Context, _ classifier.PullRequestRef) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.output, nil
+}
+
+type fakeFirstPassNormalizer struct {
+	review classifier.FirstPassReview
+	err    error
+}
+
+func (f fakeFirstPassNormalizer) Classify(_ context.Context, _ string) (classifier.FirstPassReview, error) {
+	if f.err != nil {
+		return classifier.FirstPassReview{}, f.err
+	}
+	return f.review, nil
+}
+
+func TestFirstPassReviewReadyToMerge(t *testing.T) {
+	review := baselineFirstPassReview()
+	review.Optimality.Verdict = classifier.OptimalityVerdictAcceptable
+
+	service := FirstPassService{
+		Stage1:        fakeFirstPassStage1{output: "ok"},
+		Normalizer:    fakeFirstPassNormalizer{review: review},
+		MinConfidence: 0.5,
+	}
+
+	result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-1")
+
+	if result.MergeReadiness != classifier.MergeReadinessReadyToMerge {
+		t.Fatalf("expected ready_to_merge, got %s", result.MergeReadiness)
+	}
+	if result.RunID != "run-1" {
+		t.Fatalf("expected run_id to be set, got %s", result.RunID)
+	}
+}
+
+func TestFirstPassReviewWIPRules(t *testing.T) {
+	tests := []struct {
+		name   string
+		review classifier.FirstPassReview
+	}{
+		{
+			name: "intent partial",
+			review: func() classifier.FirstPassReview {
+				candidate := baselineFirstPassReview()
+				candidate.IntentUnderstanding.Verdict = classifier.IntentVerdictPartial
+				return candidate
+			}(),
+		},
+		{
+			name: "optimality unknown",
+			review: func() classifier.FirstPassReview {
+				candidate := baselineFirstPassReview()
+				candidate.Optimality.Verdict = classifier.OptimalityVerdictUnknown
+				return candidate
+			}(),
+		},
+		{
+			name: "blocking questions present",
+			review: func() classifier.FirstPassReview {
+				candidate := baselineFirstPassReview()
+				candidate.BlockingQuestions = []string{"Can this break in prod?"}
+				return candidate
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := FirstPassService{
+				Stage1:        fakeFirstPassStage1{output: "ok"},
+				Normalizer:    fakeFirstPassNormalizer{review: tt.review},
+				MinConfidence: 0.5,
+			}
+
+			result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-2")
+			if result.MergeReadiness != classifier.MergeReadinessWIP {
+				t.Fatalf("expected wip, got %s", result.MergeReadiness)
+			}
+		})
+	}
+}
+
+func TestFirstPassReviewFallbackRules(t *testing.T) {
+	t.Run("stage1 failure", func(t *testing.T) {
+		service := FirstPassService{
+			Stage1:        fakeFirstPassStage1{err: errors.New("boom")},
+			Normalizer:    fakeFirstPassNormalizer{review: baselineFirstPassReview()},
+			MinConfidence: 0.5,
+		}
+
+		result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-3")
+		if result.MergeReadiness != classifier.MergeReadinessNeedsHumanReview {
+			t.Fatalf("expected needs_human_review, got %s", result.MergeReadiness)
+		}
+	})
+
+	t.Run("stage2 failure", func(t *testing.T) {
+		service := FirstPassService{
+			Stage1:        fakeFirstPassStage1{output: "ok"},
+			Normalizer:    fakeFirstPassNormalizer{err: errors.New("normalize failed")},
+			MinConfidence: 0.5,
+		}
+
+		result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-4")
+		if result.MergeReadiness != classifier.MergeReadinessNeedsHumanReview {
+			t.Fatalf("expected needs_human_review, got %s", result.MergeReadiness)
+		}
+	})
+
+	t.Run("low confidence", func(t *testing.T) {
+		lowConfidence := baselineFirstPassReview()
+		lowConfidence.IntentUnderstanding.Confidence = 0.2
+
+		service := FirstPassService{
+			Stage1:        fakeFirstPassStage1{output: "ok"},
+			Normalizer:    fakeFirstPassNormalizer{review: lowConfidence},
+			MinConfidence: 0.5,
+		}
+
+		result := service.Review(context.Background(), "https://github.com/RohanAwhad/new-math-mnist/pull/9", "run-5")
+		if result.MergeReadiness != classifier.MergeReadinessNeedsHumanReview {
+			t.Fatalf("expected needs_human_review, got %s", result.MergeReadiness)
+		}
+	})
+}
+
+func baselineFirstPassReview() classifier.FirstPassReview {
+	intent := "Package-first migration with API exports"
+	return classifier.FirstPassReview{
+		IntentUnderstanding: classifier.IntentUnderstanding{
+			Verdict:          classifier.IntentVerdictYes,
+			Confidence:       0.91,
+			Reason:           "Intent is explicit in commits and files",
+			UnderstoodIntent: &intent,
+		},
+		Optimality: classifier.OptimalityAssessment{
+			Verdict:      classifier.OptimalityVerdictOptimal,
+			Reason:       "Approach minimizes churn and clarifies imports",
+			Alternatives: []string{},
+		},
+		FocusAreas:        []classifier.FocusArea{},
+		BlockingQuestions: []string{},
+	}
+}


### PR DESCRIPTION
## Why
- Establish a typed first-pass review contract and deterministic routing before CLI wiring.
- Isolate merge-readiness policy review from runtime and docs changes.

## Scope
- In:
  - First-pass domain types and enums.
  - Stage-2 first-pass normalizer and token canonicalization.
  - First-pass pipeline service and readiness/fallback tests.
- Out:
  - Stage-1 runner configurability.
  - CLI entrypoint and smoke/doc updates.

## Changes
- Add `internal/classifier/first_pass.go` for first-pass payload contracts.
- Add `internal/normalize/first_pass.go` for normalized tool-output parsing.
- Add `internal/pipeline/first_pass_service.go` and `internal/pipeline/first_pass_service_test.go` for routing + fallback policy.

## Validation
- [x] `go test ./...` -> pass
- [x] `go test ./internal/pipeline -run FirstPass` -> pass
- [x] Manual check: fallback path always emits `needs_human_review` with a blocking reason.

## Risk
- Risk level: [x] Low [ ] Medium [ ] High
- Main risk: Over-normalizing model tokens to unintended enum values.
- Mitigation: Strict enum mapping + fallback defaults + pipeline tests for readiness branches.
- Rollback: Revert this PR commit.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [ ] Docs updated (if behavior/usage changed)