### PR TITLE
feat: add first-pass CLI command

### DIFF
--- a/cmd/first-pass/main.go
+++ b/cmd/first-pass/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/RohanAwhad/pr-review-bot/internal/logging"
+	"github.com/RohanAwhad/pr-review-bot/internal/normalize"
+	"github.com/RohanAwhad/pr-review-bot/internal/pipeline"
+	"github.com/RohanAwhad/pr-review-bot/internal/stage1"
+)
+
+const firstPassPrompt = "You are stage-1 first-pass PR reviewer. Analyze this checked-out PR branch against main. First inspect commit history and changed-file list. Then read full contents of the key changed files (not just patch snippets) before deciding intent and optimality. You may run installs/tests and use external references when needed to remove uncertainty. Keep output concise. End with these fields: INTENT_VERDICT, UNDERSTOOD_INTENT, INTENT_CONFIDENCE, INTENT_REASON, OPTIMALITY_VERDICT, OPTIMALITY_REASON, ALTERNATIVES, FOCUS_AREAS, BLOCKING_QUESTIONS."
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: first-pass <github-pr-url>\n")
+		os.Exit(2)
+	}
+	prURL := os.Args[1]
+
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve working directory: %v\n", err)
+		os.Exit(1)
+	}
+	loadDotEnv(filepath.Join(wd, ".env"))
+
+	logger, logSink, logPath, err := logging.New("first-pass")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configure logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer logSink.Close()
+	slog.SetDefault(logger)
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Error("panic recovered", "panic", recovered, "stack", string(debug.Stack()))
+			os.Exit(1)
+		}
+	}()
+
+	id := runID()
+	runLogger := logger.With("run_id", id, "pr_url", prURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	project := envOr("GOOGLE_CLOUD_PROJECT", os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"))
+	region := envOr("CLOUD_ML_REGION", "us-east5")
+	model := envOr("NORMALIZER_MODEL", "claude-haiku-4-5@20251001")
+	image := envOr("PR_REVIEW_BOT_STAGE1_IMAGE", envOr("STAGE1_IMAGE", "pr-review-bot-stage1:latest"))
+	stage1Model := os.Getenv("STAGE1_MODEL")
+	runLogger.Info("starting first-pass review", "image", image, "normalizer_model", model, "stage1_model", stage1Model)
+
+	normalizer := normalize.NewFirstPass(ctx, region, project, model)
+	normalizer.Logger = runLogger
+
+	service := pipeline.FirstPassService{
+		Stage1: stage1.Runner{
+			Image:    image,
+			RepoRoot: wd,
+			Prompt:   firstPassPrompt,
+			Agent:    "build",
+			Model:    stage1Model,
+			Logger:   runLogger,
+		},
+		Normalizer:    normalizer,
+		MinConfidence: confidenceThreshold(),
+		Logger:        runLogger,
+	}
+
+	review := service.Review(ctx, prURL, id)
+	runLogger.Info("first-pass review completed", "merge_readiness", review.MergeReadiness, "intent_verdict", review.IntentUnderstanding.Verdict, "optimality_verdict", review.Optimality.Verdict)
+
+	out, err := json.MarshalIndent(review, "", "  ")
+	if err != nil {
+		runLogger.Error("encode review JSON", "error", err)
+		fmt.Fprintf(os.Stderr, "encode review JSON: %v\n", err)
+		os.Exit(1)
+	}
+	runLogger.Debug("writing first-pass review JSON to stdout", "log_path", logPath)
+	fmt.Println(string(out))
+}
+
+func runID() string {
+	return fmt.Sprintf("run-%d-%06d", time.Now().Unix(), rand.Intn(1000000))
+}
+
+func confidenceThreshold() float64 {
+	value := envOr("MIN_CONFIDENCE", "0.5")
+	v, err := strconv.ParseFloat(value, 64)
+	if err != nil || v < 0 || v > 1 {
+		return 0.5
+	}
+	return v
+}
+
+func envOr(key string, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func loadDotEnv(path string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		if key == "" || os.Getenv(key) != "" {
+			continue
+		}
+
+		value := strings.TrimSpace(parts[1])
+		value = strings.TrimPrefix(value, "\"")
+		value = strings.TrimSuffix(value, "\"")
+		_ = os.Setenv(key, value)
+	}
+}


### PR DESCRIPTION
## Why
- Introduce a dedicated first-pass CLI to produce structured intent/optimality/readiness output from a PR URL.
- Keep CLI orchestration review separate from core policy and docs/smoke updates.

## Scope
- In:
  - New `first-pass` command wiring stage-1 + stage-2 + JSON output.
  - First-pass prompt/agent selection and confidence threshold handling.
- Out:
  - Smoke script changes.
  - README/devlogs updates.

## Changes
- Add `cmd/first-pass/main.go` with dotenv loading, logging sink setup, and run-id based execution.
- Wire `pipeline.FirstPassService` with custom first-pass prompt and `build` agent.
- Emit normalized first-pass JSON with merge-readiness and fallback semantics.

## Validation
- [x] `go test ./...` -> pass
- [x] `go run ./cmd/first-pass "https://github.com/RohanAwhad/new-math-mnist/issues/9"` -> returns `merge_readiness: needs_human_review`
- [x] Manual check: command emits structured JSON payload including intent/optimality/focus fields.

## Risk
- Risk level: [ ] Low [x] Medium [ ] High
- Main risk: Prompt behavior drift could affect stage-1 output quality.
- Mitigation: Keep deterministic stage-2 schema + fallback policy for parse/failure cases.
- Rollback: Revert this PR commit.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [ ] Docs updated (if behavior/usage changed)