### PR TITLE
docs: expand first-pass smoke coverage and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Phase 0 implements:
 - Input: GitHub PR URL
 - Output: JSON classification (`human_required` or `no_human`)
+- Output: JSON first-pass review (`ready_to_merge`, `wip`, or `needs_human_review`)
 
 Architecture:
 - Stage 1 (inside Podman): `opencode` (Opus 4.6) reviews checked-out PR
@@ -35,7 +36,44 @@ PR_REVIEW_BOT_STAGE1_IMAGE=pr-review-bot-stage1:latest \
 
 If `PR_REVIEW_BOT_STAGE1_IMAGE` is not set, the CLI falls back to `STAGE1_IMAGE`, then `pr-review-bot-stage1:latest`.
 
-Output shape:
+## Run first-pass review
+
+```bash
+PR_REVIEW_BOT_STAGE1_IMAGE=pr-review-bot-stage1:latest \
+./bin/first-pass "https://github.com/RohanAwhad/new-math-mnist/pull/9"
+```
+
+First-pass output shape:
+
+```json
+{
+  "intent_understanding": {
+    "verdict": "yes",
+    "confidence": 0.92,
+    "reason": "Intent is explicit in commit and diff history",
+    "understood_intent": "Migrate project to package-first API and update docs/tests accordingly"
+  },
+  "optimality": {
+    "verdict": "acceptable",
+    "reason": "Approach is mostly sound but leaves one follow-up refactor",
+    "alternatives": ["Move dataset loader to dedicated module in this PR"]
+  },
+  "merge_readiness": "wip",
+  "focus_areas": [
+    {
+      "path": "new_math_ops/dataset.py",
+      "why": "Still re-exports from evaluate module",
+      "priority": "medium"
+    }
+  ],
+  "blocking_questions": [
+    "Is removing top-level compatibility shims approved for this release?"
+  ],
+  "run_id": "run-1741740000-123456"
+}
+```
+
+Classifier output shape:
 
 ```json
 {
@@ -65,5 +103,6 @@ KEEP_SMOKE_LOGS=1 ./scripts/smoke_phase0.sh
 - Stage-1 timeout is fixed at 30 minutes.
 - Confidence threshold defaults to `0.5` and can be overridden with `MIN_CONFIDENCE`.
 - Normalizer model defaults to `claude-haiku-4-5@20251001` and can be overridden with `NORMALIZER_MODEL`.
-- Logs are written to `logs/classify-pr.log` and mirrored to stderr.
+- Stage-1 model can be overridden with `STAGE1_MODEL` (otherwise OpenCode config default is used).
+- Logs are written to `logs/classify-pr.log` and `logs/first-pass.log`, mirrored to stderr.
 - `LOGGING_LEVEL` controls verbosity (`debug`, `info`, `warn`, `error`); default is `warn`.

--- a/devlogs.md
+++ b/devlogs.md
@@ -23,3 +23,12 @@
 - Added `scripts/smoke_phase0.sh` to run 3 classification smoke tests in parallel.
 - Captured each run to separate files, then printed section-wise output summaries.
 - Added auto-cleanup for smoke artifacts with optional `KEEP_SMOKE_LOGS=1` retention.
+- Expanded smoke coverage to include `first-pass` expectations for `new-math-mnist#9` and `agentic-rl#1`.
+
+## 2026-03-11 - First-pass review pipeline
+
+- Added `first-pass` CLI to generate initial PR review output from a GitHub PR URL.
+- Added stage-2 normalizer schema for intent understanding, optimality verdict, focus areas, and blocking questions.
+- Added deterministic merge readiness policy: low confidence/errors => `needs_human_review`, otherwise route to `wip` or `ready_to_merge`.
+- Added stage-1 runner options for model override (`STAGE1_MODEL`) and context-file mode used by first-pass.
+- Added unit tests for first-pass routing logic and fallback behavior.

--- a/scripts/smoke_phase0.sh
+++ b/scripts/smoke_phase0.sh
@@ -6,13 +6,35 @@ RUN_ID="$(date +%Y%m%d_%H%M%S)"
 RUN_DIR="${ROOT_DIR}/logs/smoke/run-${RUN_ID}"
 KEEP_SMOKE_LOGS="${KEEP_SMOKE_LOGS:-0}"
 
-CASE_NAMES=("reward_hub_64" "new_math_mnist_9" "invalid_issue_url")
+CASE_NAMES=(
+  "reward_hub_64"
+  "new_math_mnist_9"
+  "invalid_issue_url"
+  "first_pass_new_math_mnist_9"
+  "first_pass_agentic_rl_1"
+)
+CASE_COMMANDS=(
+  "classify-pr"
+  "classify-pr"
+  "classify-pr"
+  "first-pass"
+  "first-pass"
+)
 CASE_URLS=(
   "https://github.com/Red-Hat-AI-Innovation-Team/reward_hub/pull/64"
   "https://github.com/RohanAwhad/new-math-mnist/pull/9"
   "https://github.com/RohanAwhad/new-math-mnist/issues/9"
+  "https://github.com/RohanAwhad/new-math-mnist/pull/9"
+  "https://github.com/RohanAwhad/agentic-rl/pull/1"
 )
-CASE_EXPECTED=("no_human" "human_required" "human_required")
+CASE_EXPECTED=("no_human" "human_required" "human_required" "ready_to_merge" "wip")
+CASE_JSON_FIELDS=(
+  "classification"
+  "classification"
+  "classification"
+  "merge_readiness"
+  "merge_readiness"
+)
 
 cleanup() {
   if [[ "${KEEP_SMOKE_LOGS}" != "1" ]]; then
@@ -31,15 +53,20 @@ for i in "${!CASE_NAMES[@]}"; do
   stdout_file="${RUN_DIR}/${CASE_NAMES[$i]}.stdout"
   stderr_file="${RUN_DIR}/${CASE_NAMES[$i]}.stderr"
   status_file="${RUN_DIR}/${CASE_NAMES[$i]}.exit"
+  command_name="${CASE_COMMANDS[$i]}"
   (
-    go run ./cmd/classify-pr "${CASE_URLS[$i]}" >"${stdout_file}" 2>"${stderr_file}"
+    go run "./cmd/${command_name}" "${CASE_URLS[$i]}" >"${stdout_file}" 2>"${stderr_file}"
     echo "$?" >"${status_file}"
     exit 0
   ) &
   PIDS+=("$!")
 done
 
-for pid in "${PIDS[@]}"; do wait "${pid}"; done
+for pid in "${PIDS[@]}"; do
+  if ! wait "${pid}"; then
+    :
+  fi
+done
 
 pass_count=0
 mismatch_count=0
@@ -48,6 +75,7 @@ error_count=0
 for i in "${!CASE_NAMES[@]}"; do
   name="${CASE_NAMES[$i]}"
   expected="${CASE_EXPECTED[$i]}"
+  json_field="${CASE_JSON_FIELDS[$i]}"
   stdout_file="${RUN_DIR}/${name}.stdout"
   stderr_file="${RUN_DIR}/${name}.stderr"
   status_file="${RUN_DIR}/${name}.exit"
@@ -63,7 +91,7 @@ for i in "${!CASE_NAMES[@]}"; do
     actual="command-failed"
     ((error_count+=1))
   else
-    actual="$(jq -r '.classification // empty' "${stdout_file}" 2>/dev/null || true)"
+    actual="$(jq -r --arg field "${json_field}" '.[$field] // empty' "${stdout_file}" 2>/dev/null || true)"
     if [[ -z "${actual}" ]]; then
       status="ERROR"
       actual="invalid-json"
@@ -78,7 +106,9 @@ for i in "${!CASE_NAMES[@]}"; do
   fi
 
   echo "===== ${name} ====="
+  echo "Command: ${CASE_COMMANDS[$i]}"
   echo "URL: ${CASE_URLS[$i]}"
+  echo "JSON field: ${json_field}"
   echo "Expected: ${expected}"
   echo "Actual: ${actual}"
   echo "Status: ${status}"


### PR DESCRIPTION
## Why
- Document first-pass usage/output and make smoke checks assert both classifier and first-pass expectations.
- Keep operational/documentation review isolated from code-path implementation.

## Scope
- In:
  - Smoke script support for command-per-case and field-aware assertions.
  - README updates for first-pass command, output shape, and environment knobs.
  - Devlog updates capturing first-pass rollout milestones.
- Out:
  - Core routing or runner logic changes.

## Changes
- Update `scripts/smoke_phase0.sh` to run both `classify-pr` and `first-pass` cases with per-case JSON field checks.
- Update `README.md` with first-pass execution example, output schema, and config notes.
- Update `devlogs.md` with first-pass pipeline and smoke expansion entries.

## Validation
- [x] `bash -n scripts/smoke_phase0.sh` -> pass
- [x] `go test ./...` -> pass
- [x] Manual check: smoke summary now prints command name and JSON field for each case.

## Risk
- Risk level: [x] Low [ ] Medium [ ] High
- Main risk: Shell control-flow mistakes could hide per-case failures.
- Mitigation: explicit per-case status files + guarded wait loop + mismatch/error counters.
- Rollback: Revert this PR commit.

## Checklist
- [x] Self-review done
- [x] No unrelated changes
- [x] Tests/type checks updated as needed
- [x] Docs updated (if behavior/usage changed)